### PR TITLE
Fixed movement - fully working save for a small known issue

### DIFF
--- a/scripts/scr_worker_move/scr_worker_move.gml
+++ b/scripts/scr_worker_move/scr_worker_move.gml
@@ -186,32 +186,6 @@ if !validPathFound {
 						direction_to_search_in_ -= 4;
 					}
 				}
-				
-				/*if right_n_ > 0 {
-					direction_to_search_in_ = 0;
-					top_n_ = right_n_ - 1;
-					left_n_ = right_n_ - 1;
-					bottom_n_ = right_n_ - 1;
-				}
-				else if top_n_ > 0 {
-					direction_to_search_in_ = 1;
-					right_n_ = top_n_;
-					left_n_ = top_n_ - 1;
-					bottom_n_ = top_n_ - 1;
-				}
-				else if left_n_ > 0 {
-					direction_to_search_in_ = 2;
-					right_n_ = left_n_;
-					top_n_ = left_n_;
-					bottom_n_ = left_n_ - 1;
-				}
-				else if bottom_n_ > 0 {
-					direction_to_search_in_ = 3;
-					right_n_ = bottom_n_;
-					top_n_ = bottom_n_;
-					left_n_ = bottom_n_;
-				}
-				*/
 				// After resetting variables to where they were before pausing the search,
 				// I need to increment direction_to_search_in_, since that is normally
 				// done at the end of the while loop but is always skipped over in case 
@@ -485,9 +459,8 @@ if !validPathFound {
 					}
 					// Increment an important variable
 					totalTimesSearched++;
-					var x_lol_ = current_target_to_move_to_x_;
-					var y_lol_ = current_target_to_move_to_y_;
-					var yeet_ = 1;
+					// Reset local variables that need resetting
+					forbidden_to_search_ = false;
 				}
 			}
 		}


### PR DESCRIPTION
-Movement bug that was fixed was a small issue where ordering a unit to move to a location where an invalid spot was closer would stop the movement completely. Simple fix simply by adding a single line resetting invalidity of the search.

KNOWN ISSUES
-If the click location does not have any valid move-to location within a plus sign design centered on click location throughout the map, movement will freeze. A simple fix will be added in, expanding the search area in case no valid path is found at first, with a guaranteed path to eventually be found.