### PR TITLE
Player objects will be the only objects selected

### DIFF
--- a/Pride of Pixels.yyp
+++ b/Pride of Pixels.yyp
@@ -1,5 +1,6 @@
 {
   "resources": [
+    {"id":{"name":"unit_attack","path":"scripts/unit_attack/unit_attack.yy",},"order":2,},
     {"id":{"name":"test_sprite","path":"sprites/test_sprite/test_sprite.yy",},"order":0,},
     {"id":{"name":"spr_mouse_highlight","path":"sprites/spr_mouse_highlight/spr_mouse_highlight.yy",},"order":4,},
     {"id":{"name":"spr_mouse_drag_vertical_line","path":"sprites/spr_mouse_drag_vertical_line/spr_mouse_drag_vertical_line.yy",},"order":5,},
@@ -20,7 +21,7 @@
     {"id":{"name":"spr_selected","path":"sprites/spr_selected/spr_selected.yy",},"order":7,},
     {"id":{"name":"spr_toolbar_background","path":"sprites/spr_toolbar_background/spr_toolbar_background.yy",},"order":2,},
     {"id":{"name":"tile_grass_1","path":"tilesets/tile_grass_1/tile_grass_1.yy",},"order":0,},
-    {"id":{"name":"Reset_Variables","path":"scripts/Reset_Variables/Reset_Variables.yy",},"order":0,},
+    {"id":{"name":"clear_selections","path":"scripts/clear_selections/clear_selections.yy",},"order":0,},
     {"id":{"name":"unit_move","path":"scripts/unit_move/unit_move.yy",},"order":0,},
     {"id":{"name":"obj_camera_inputs_and_gui","path":"objects/obj_camera_inputs_and_gui/obj_camera_inputs_and_gui.yy",},"order":0,},
     {"id":{"name":"obj_mp_grid_controller","path":"objects/obj_mp_grid_controller/obj_mp_grid_controller.yy",},"order":0,},

--- a/objects/obj_worker/CleanUp_0.gml
+++ b/objects/obj_worker/CleanUp_0.gml
@@ -1,4 +1,4 @@
-// 
+// Clean up potential memory leaks
 if ds_exists(unitGridLocation, ds_type_grid) {
 	if ds_grid_value_exists(unitGridLocation, 0, 0, 1, ds_grid_height(unitGridLocation) - 1, self.id) {
 		if ds_grid_height(unitGridLocation) > 1 {

--- a/scripts/clear_selections/clear_selections.gml
+++ b/scripts/clear_selections/clear_selections.gml
@@ -1,4 +1,5 @@
 /// @function					clear_selections();
+/// @parameter					[optional]id_or_object_index
 /// @description				Takes a variable number of parameters {index} and resets
 ///								selection variables on the object(s).
 
@@ -12,7 +13,9 @@ function clear_selections() {
 					objectSelected = false;
 					if ds_exists(objectsSelectedList, ds_type_list) {
 						if ds_list_size(objectsSelectedList) > 1 {
-							ds_list_delete(objectsSelectedList, ds_list_find_index(objectsSelectedList, self.id));
+							if ds_list_find_index(objectsSelectedList, self.id) != -1 {
+								ds_list_delete(objectsSelectedList, ds_list_find_index(objectsSelectedList, self.id));
+							}
 						}
 						else {
 							ds_list_destroy(objectsSelectedList);

--- a/scripts/clear_selections/clear_selections.yy
+++ b/scripts/clear_selections/clear_selections.yy
@@ -6,7 +6,7 @@
     "path": "folders/Scripts/Internal_Code_Exclusive.yy",
   },
   "resourceVersion": "1.0",
-  "name": "Reset_Variables",
+  "name": "clear_selections",
   "tags": [
     "internal",
   ],

--- a/scripts/unit_attack/unit_attack.gml
+++ b/scripts/unit_attack/unit_attack.gml
@@ -1,0 +1,6 @@
+/// @function								unit_attack();
+/// @description							Attack nearest enemy objects, whether they be buildings or units.
+
+function unit_attack() {
+	
+}

--- a/scripts/unit_attack/unit_attack.yy
+++ b/scripts/unit_attack/unit_attack.yy
@@ -1,0 +1,12 @@
+{
+  "isDnD": false,
+  "isCompatibility": false,
+  "parent": {
+    "name": "Unit_Specific",
+    "path": "folders/Scripts/Unit_Specific.yy",
+  },
+  "resourceVersion": "1.0",
+  "name": "unit_attack",
+  "tags": [],
+  "resourceType": "GMScript",
+}


### PR DESCRIPTION
Player objects will be the only objects selected if a wide selection encompassing multiple teams and objects is made. This means that, for example, if your team gets mixed in combat with an enemy team, your selection will only encompass those that are on your team.