### PR TITLE
Internal ds_list 'objectTargetList' is now sorted correctly

### DIFF
--- a/objects/obj_unit/Step_0.gml
+++ b/objects/obj_unit/Step_0.gml
@@ -529,6 +529,38 @@ if device_mouse_y_to_gui(0) <= (view_get_hport(view_camera[0]) - obj_camera_inpu
 						}
 					}
 				}
+				// After the target_list_ is created, go through and sort that list by closest to furthest,
+				// with closest being at index 0.
+				if ds_exists(target_list_, ds_type_list) {
+					// No need to sort if there's only 1 value in the list
+					if ds_list_size(target_list_) > 1 {
+						var holding_list_ = ds_list_create();
+						ds_list_copy(holding_list_, target_list_);
+						var t, p;
+						// Start at the top of the list, to get the value to search for.
+						for (t = 0; t < ds_list_size(holding_list_); t++) {
+							var temp_instance_to_reference_ = ds_list_find_value(holding_list_, t);
+							var temp_instance_distance_ = distance_to_object(temp_instance_to_reference_);
+							// Now that I have the value and distance to search for, compare it against the 
+							// actual list, sorting downwards.
+							for (p = ds_list_size(target_list_) - 1; p >= 0; p--) {
+								var instance_to_compare_against_ = ds_list_find_value(target_list_, p);
+								var temp_compare_instance_distance_ = distance_to_object(instance_to_compare_against_);
+								// If the instance in the list is at a distance less than the instance at the bottom of the list,
+								// move it to above that further object's index in the original list.
+								if temp_instance_distance_ > temp_compare_instance_distance_ {
+									// First, delete the line that contains that instance's value
+									ds_list_delete(target_list_, ds_list_find_index(target_list_, temp_instance_to_reference_));
+									// Then, insert a new line at the correct location that contains the instance's value
+									ds_list_insert(target_list_, ds_list_find_index(target_list_, instance_to_compare_against_) + 1, temp_instance_to_reference_.id);
+									break;
+								}
+							}
+						}
+						ds_list_destroy(holding_list_);
+						holding_list_ = noone;
+					}
+				}
 				// If the object at target location is a valid target, then mine/attack it if the
 				// object selected is an object that can mine it. An object's actual "team" 
 				// (objectRealTeam) will only be set to "Neutral" if it is a resource.


### PR DESCRIPTION
- An internal ds_list is now sorted by closest to furthest away, with the closest target always being at ds_list index '0', and the furthest being at the end of the list. This rule is overwritten if a target was manually clicked on, and that target becomes set to index '0' regardless of distance, with the rest of the list being sorted correctly afterwards.

This is to prepare for more intelligent combat decisions further down the line.