### PR TITLE
Additional skills; formatting

### DIFF
--- a/Pride of Pixels.yyp
+++ b/Pride of Pixels.yyp
@@ -573,7 +573,7 @@
   ],
   "IncludedFiles": [],
   "MetaData": {
-    "IDEVersion": "2022.1.0.609",
+    "IDEVersion": "2022.1.1.610",
   },
   "resourceVersion": "1.4",
   "name": "Pride of Pixels",

--- a/notes/BarracksSkillTree/BarracksSkillTree.txt
+++ b/notes/BarracksSkillTree/BarracksSkillTree.txt
@@ -11,10 +11,10 @@ TIER 3 UPGRADES - AVAILABLE AT GAME CREATION
 - SPECIAL 1a -	Unlocks the Berserker's Standard Ability, Enrage.
 - SPECIAL 1b -	Unlocks the Rogue's Standard Ability, Invisibility.
 - SPECIAL 1c -	Unlocks the Soldier's Standard Ability, Rally.
-- SPECIAL 2 -	Unlocks the Special Ability for the basic unit chosen in your Combat
-		Specialty skill.
 
 TIER 2 UPGRADES
+- SPECIAL 2 -	Unlocks the Combat Special Ability for the basic unit chosen in your Combat
+		Specialty skill at game start.
 - OFFENSIVE 2a -Rogues are able to find the weakpoint in armor with their Ambush ability
 		and now ignore half of the target's armor when attacking with Ambush.
 - OFFENSIVE 2b -Further increases the range of Rangers.

--- a/notes/TempleSkillTree/TempleSkillTree.txt
+++ b/notes/TempleSkillTree/TempleSkillTree.txt
@@ -4,10 +4,11 @@ GAME START
 
 
 TIER 3 UPGRADES
-- SPECIAL 1 -	Special Abilities: Unlocks the Special Ability for the ruby unit chosen in your Combat
-		Specialty skill.
 
 TIER 2 UPGRADES
+- SPECIAL 1a -	Special Abilities: Unlocks Special Abilities for all Ruby units.
+- SPECIAL 1b -	Combat Special Abilities: Unlocks the Combat Special Ability for the ruby unit chosen 
+				in your Combat Specialty skill at game start.
 - SPECIAL 2a -	Ruby Units: Allows ruby units to be built.
 - INNOVATION 1a Ordained: Acolyte healing is increased.
 - INNOVATION 1b Swift Footed: Subverters gain additional movement speed.
@@ -21,11 +22,11 @@ MAGICAL UPGRADES
 		can choose a target location on the map for all linked Wizards to attack. The
 		linked Wizards launch fireballs at the target location, dealing damage to all
 		enemies within that location.
-- INNOVATION 2b Shrine of Vitality: Unlocks the Link ability for Acolytes, allowing one to link 
+- INNOVATION 2b Vitality Linked: Unlocks the Link ability for Acolytes, allowing one to link 
 		with two others. The group of linked Acolytes lose the ability to heal normally, 
 		but the player can choose a target location on the map for all linked Acolytes to 
-		heal. The linked Acolytes launch fireballs at the target location, healing all allies
-		within that location. 
+		heal. The linked Acolytes infuse the location with healing magic, healing all friendly
+		units within that location.
 TECHNOLOGY UPGRADES
 - SPECIAL 2b -	Automatons: Allows Automatons to be built.
 - INNOVATION 2 -Shocktroopers: Unlocks the Shocktroopers ability for Automatons, allowing the player to

--- a/objects/obj_unit/Create_0.gml
+++ b/objects/obj_unit/Create_0.gml
@@ -58,7 +58,6 @@ groupRowWidth = 0;
 specificLocationNeedsToBeChecked = false;
 specificLocationToBeCheckedX = -1;
 specificLocationToBeCheckedY = -1;
-movementSpeed = 2;
 searchHasJustBegun = true;
 totalTimesSearched = 0;
 closestSearchPointToObjectX = -1;

--- a/objects/obj_unit/Step_0.gml
+++ b/objects/obj_unit/Step_0.gml
@@ -40,7 +40,7 @@ if !obj_gui.startMenu.active {
 					if break_ {
 						break;
 					}
-					if currentSprite == workerSprite[i][j] {
+					if currentSprite == unitSprite[i][j] {
 						current_action_ = i;
 						current_direction_facing_ = j;
 						break_ = true;
@@ -50,7 +50,7 @@ if !obj_gui.startMenu.active {
 		}
 		if (current_action_ != -1) && (current_direction_facing_ != -1) {
 			if current_direction_facing_ != currentDirection {
-				currentSprite = workerSprite[current_action_][currentDirection];
+				currentSprite = unitSprite[current_action_][currentDirection];
 			}
 		}
 	}
@@ -65,19 +65,19 @@ if !obj_gui.startMenu.active {
 		/// Apply a wait time to different animations, so that the animation lines up with the action taken on the other object.
 		// If the object's current action is simply to idle or move, just set the sprite normally.
 		if (currentAction == unitAction.idle) || (currentAction == unitAction.move) {
-			currentSprite = workerSprite[currentAction][currentDirection];
+			currentSprite = unitSprite[currentAction][currentDirection];
 		}
 		// However, if the object's current action is to mine, chop, farm, or attack, check to see if its currently idling.
-		else if (currentSprite == workerSprite[unitAction.idle][currentDirection]) || (currentSprite == workerSprite[unitAction.move][currentDirection]) {
+		else if (currentSprite == unitSprite[unitAction.idle][currentDirection]) || (currentSprite == unitSprite[unitAction.move][currentDirection]) {
 			if (currentAction == unitAction.mine) || (currentAction == unitAction.chop) || (currentAction == unitAction.farm) || (currentAction == unitAction.attack) {
 				// If the object is still commanded to mine, chop, farm, or attack, and the idle time is over, start the action animation.
 				if spriteWaitTimer <= 0 {
-					currentSprite = workerSprite[currentAction][currentDirection];
+					currentSprite = unitSprite[currentAction][currentDirection];
 				}
 			}
 			// Redundant to prevent errors.
 			else {
-				currentSprite = workerSprite[currentAction][currentDirection];
+				currentSprite = unitSprite[currentAction][currentDirection];
 			}
 		}
 		// Else if the object's action is to mine, chop, farm, or attack, and it is not currently idling, and obviously the animation
@@ -85,7 +85,7 @@ if !obj_gui.startMenu.active {
 		// action, just sprite) to idling and wait until its time to act again - that's set to 3 frames before the action is set to
 		// activate, because I want the animation to happen slightly before the action itself occurs, to more accurately line up the
 		// middle of the animation with the action itself.
-		else if currentSprite == workerSprite[currentAction][currentDirection] {
+		else if currentSprite == unitSprite[currentAction][currentDirection] {
 			if (currentAction != unitAction.idle) && (currentAction != unitAction.move) {
 				switch currentAction {
 					case unitAction.mine:
@@ -109,7 +109,7 @@ if !obj_gui.startMenu.active {
 						break;
 				}
 			}
-			currentSprite = workerSprite[unitAction.idle][currentDirection]
+			currentSprite = unitSprite[unitAction.idle][currentDirection]
 		}
 	}
 	sprite_index = currentSprite;

--- a/scripts/initialize_object_data/initialize_object_data.gml
+++ b/scripts/initialize_object_data/initialize_object_data.gml
@@ -12,6 +12,7 @@ enum unitAction {
 	chop,
 	farm,
 	attack,
+	specialAttack,
 	length
 }
 // Sprite setting enums
@@ -79,7 +80,13 @@ function initialize_object_data() {
 			maxHP = 70;
 			currentHP = maxHP;
 			objectRange = 16;
+			movementSpeed = 1;
+			objectIsRubyUnit = false;
 			// Availability variables
+			objectHasSpecialAbility = false;
+			objectCanUseSpecialAbility = false;
+			objectHasCombatSpecializationAbility = false;
+			objectCanUseCombatSpecializationAbility = false;
 			canBuildFarm = false;
 			canBuildThicket = false;
 			canBuildMine = false;
@@ -98,8 +105,6 @@ function initialize_object_data() {
 			objectAttackSpeedTimer = 0;
 			objectAttackDamage = 12;
 			objectAttackDamageType = "Slash";
-			objectIsRubyUnit = false;
-			objectCanUseSpecialAbility = false;
 			// For resistances, they're multipliers. The closer to 0 the higher resistance it has.
 			// Anything above 1 means it has a negative resistance and takes more damage than normal
 			// from that damage type.
@@ -120,34 +125,34 @@ function initialize_object_data() {
 			objectRubyMineSpeedTimer = 0; // Ruby
 			objectRubyMineDamage = 2; // Ruby
 			// Sprite setting array
-			workerSprite[unitAction.idle][unitDirection.right] = spr_worker_right_idle;
-			workerSprite[unitAction.idle][unitDirection.up] = spr_worker_back_idle;
-			workerSprite[unitAction.idle][unitDirection.left] = spr_worker_left_idle;
-			workerSprite[unitAction.idle][unitDirection.down] = spr_worker_front_idle;
-			workerSprite[unitAction.move][unitDirection.right] = spr_worker_right_walk;
-			workerSprite[unitAction.move][unitDirection.up] = spr_worker_back_walk;
-			workerSprite[unitAction.move][unitDirection.left] = spr_worker_left_walk;
-			workerSprite[unitAction.move][unitDirection.down] = spr_worker_front_walk;
-			workerSprite[unitAction.mine][unitDirection.right] = spr_worker_right_mine;
-			workerSprite[unitAction.mine][unitDirection.up] = spr_worker_back_mine;
-			workerSprite[unitAction.mine][unitDirection.left] = spr_worker_left_mine;
-			workerSprite[unitAction.mine][unitDirection.down] = spr_worker_front_mine;
-			workerSprite[unitAction.chop][unitDirection.right] = spr_worker_right_chop;
-			workerSprite[unitAction.chop][unitDirection.up] = spr_worker_back_chop;
-			workerSprite[unitAction.chop][unitDirection.left] = spr_worker_left_chop;
-			workerSprite[unitAction.chop][unitDirection.down] = spr_worker_front_chop;
-			workerSprite[unitAction.farm][unitDirection.right] = spr_worker_right_farm;
-			workerSprite[unitAction.farm][unitDirection.up] = spr_worker_back_farm;
-			workerSprite[unitAction.farm][unitDirection.left] = spr_worker_left_farm;
-			workerSprite[unitAction.farm][unitDirection.down] = spr_worker_front_farm;
-			workerSprite[unitAction.attack][unitDirection.right] = spr_worker_right_attack;
-			workerSprite[unitAction.attack][unitDirection.up] = spr_worker_back_attack;
-			workerSprite[unitAction.attack][unitDirection.left] = spr_worker_left_attack;
-			workerSprite[unitAction.attack][unitDirection.down] = spr_worker_front_attack;
+			unitSprite[unitAction.idle][unitDirection.right] = spr_worker_right_idle;
+			unitSprite[unitAction.idle][unitDirection.up] = spr_worker_back_idle;
+			unitSprite[unitAction.idle][unitDirection.left] = spr_worker_left_idle;
+			unitSprite[unitAction.idle][unitDirection.down] = spr_worker_front_idle;
+			unitSprite[unitAction.move][unitDirection.right] = spr_worker_right_walk;
+			unitSprite[unitAction.move][unitDirection.up] = spr_worker_back_walk;
+			unitSprite[unitAction.move][unitDirection.left] = spr_worker_left_walk;
+			unitSprite[unitAction.move][unitDirection.down] = spr_worker_front_walk;
+			unitSprite[unitAction.mine][unitDirection.right] = spr_worker_right_mine;
+			unitSprite[unitAction.mine][unitDirection.up] = spr_worker_back_mine;
+			unitSprite[unitAction.mine][unitDirection.left] = spr_worker_left_mine;
+			unitSprite[unitAction.mine][unitDirection.down] = spr_worker_front_mine;
+			unitSprite[unitAction.chop][unitDirection.right] = spr_worker_right_chop;
+			unitSprite[unitAction.chop][unitDirection.up] = spr_worker_back_chop;
+			unitSprite[unitAction.chop][unitDirection.left] = spr_worker_left_chop;
+			unitSprite[unitAction.chop][unitDirection.down] = spr_worker_front_chop;
+			unitSprite[unitAction.farm][unitDirection.right] = spr_worker_right_farm;
+			unitSprite[unitAction.farm][unitDirection.up] = spr_worker_back_farm;
+			unitSprite[unitAction.farm][unitDirection.left] = spr_worker_left_farm;
+			unitSprite[unitAction.farm][unitDirection.down] = spr_worker_front_farm;
+			unitSprite[unitAction.attack][unitDirection.right] = spr_worker_right_attack;
+			unitSprite[unitAction.attack][unitDirection.up] = spr_worker_back_attack;
+			unitSprite[unitAction.attack][unitDirection.left] = spr_worker_left_attack;
+			unitSprite[unitAction.attack][unitDirection.down] = spr_worker_front_attack;
 			// Actual Sprite Value
 			currentAction = unitAction.idle;
 			currentDirection = unitDirection.right;
-			currentSprite = workerSprite[currentAction][currentDirection];
+			currentSprite = unitSprite[currentAction][currentDirection];
 			spriteWaitTimer = 0;
 			movementLeaderOrFollowing = noone;
 			mask_index = spr_16_16;
@@ -155,6 +160,231 @@ function initialize_object_data() {
 			currentImageIndex = 0;
 			currentImageIndexSpeed = 8 / room_speed;
 			break;
+		// ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED
+		case "Wizard":
+			// Generic variables
+			maxHP = 100;
+			currentHP = maxHP;
+			objectRange = 16 * 4;
+			movementSpeed = 1.5;
+			objectIsRubyUnit = true;
+			// Availability variables
+			objectHasSpecialAbility = true;
+			objectCanUseSpecialAbility = false;
+			objectHasCombatSpecializationAbility = true;
+			objectCanUseCombatSpecializationAbility = false;
+			wizardsCanLink = false;
+			// Combat variables
+			objectCombatAggroRange = 10; // This is half the width of the square in mp_grid unit sizes to detect enemies in, centered on this object
+			objectAttackSpeed = 2 * room_speed;
+			objectAttackSpeedTimer = 0;
+			objectAttackDamage = 30;
+			objectAttackDamageType = "Magic";
+			objectSpecialAttackDamage = 50;
+			objectSpecialAttackDamageType = "Magic";
+			// For resistances, they're multipliers. The closer to 0 the higher resistance it has.
+			// Anything above 1 means it has a negative resistance and takes more damage than normal
+			// from that damage type.
+			objectSlashResistance = 1.25;
+			objectPierceResistance = 1;
+			objectMagicResistance = 0.95;
+			// Sprite setting array
+			unitSprite[unitAction.idle][unitDirection.right] = spr_wizard_right_idle;
+			unitSprite[unitAction.idle][unitDirection.up] = spr_wizard_back_idle;
+			unitSprite[unitAction.idle][unitDirection.left] = spr_wizard_left_idle;
+			unitSprite[unitAction.idle][unitDirection.down] = spr_wizard_front_idle;
+			unitSprite[unitAction.move][unitDirection.right] = spr_wizard_right_walk;
+			unitSprite[unitAction.move][unitDirection.up] = spr_wizard_back_walk;
+			unitSprite[unitAction.move][unitDirection.left] = spr_wizard_left_walk;
+			unitSprite[unitAction.move][unitDirection.down] = spr_wizard_front_walk;
+			unitSprite[unitAction.attack][unitDirection.right] = spr_wizard_right_attack;
+			unitSprite[unitAction.attack][unitDirection.up] = spr_wizard_back_attack;
+			unitSprite[unitAction.attack][unitDirection.left] = spr_wizard_left_attack;
+			unitSprite[unitAction.attack][unitDirection.down] = spr_wizard_front_attack;
+			unitSprite[unitAction.specialAttack][unitDirection.right] = spr_wizard_right_attack;
+			unitSprite[unitAction.specialAttack][unitDirection.up] = spr_wizard_back_attack;
+			unitSprite[unitAction.specialAttack][unitDirection.left] = spr_wizard_left_attack;
+			unitSprite[unitAction.specialAttack][unitDirection.down] = spr_wizard_front_attack;
+			// Actual Sprite Value
+			currentAction = unitAction.idle;
+			currentDirection = unitDirection.right;
+			currentSprite = unitSprite[currentAction][currentDirection];
+			spriteWaitTimer = 0;
+			movementLeaderOrFollowing = noone;
+			mask_index = spr_16_16;
+			// Index speed
+			currentImageIndex = 0;
+			currentImageIndexSpeed = 8 / room_speed;
+			break;
+		// ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED
+		case "Acolyte":
+			// Generic variables
+			maxHP = 100;
+			currentHP = maxHP;
+			objectRange = 16 * 4;
+			movementSpeed = 1.5;
+			objectIsRubyUnit = true;
+			// Availability variables
+			objectHasSpecialAbility = true;
+			objectCanUseSpecialAbility = false;
+			objectHasCombatSpecializationAbility = false;
+			objectCanUseCombatSpecializationAbility = false;
+			acolytesCanLink = false;
+			// Combat variables
+			objectCombatAggroRange = 10; // This is half the width of the square in mp_grid unit sizes to detect enemies in, centered on this object
+			objectAttackSpeed = 2 * room_speed;
+			objectAttackSpeedTimer = 0;
+			objectAttackDamage = 30;
+			objectAttackDamageType = "Magic";
+			objectSpecialAttackDamage = 50;
+			objectSpecialAttackDamageType = "Magic";
+			// For resistances, they're multipliers. The closer to 0 the higher resistance it has.
+			// Anything above 1 means it has a negative resistance and takes more damage than normal
+			// from that damage type.
+			objectSlashResistance = 1.25;
+			objectPierceResistance = 1;
+			objectMagicResistance = 0.95;
+			// Sprite setting array
+			unitSprite[unitAction.idle][unitDirection.right] = spr_wizard_right_idle;
+			unitSprite[unitAction.idle][unitDirection.up] = spr_wizard_back_idle;
+			unitSprite[unitAction.idle][unitDirection.left] = spr_wizard_left_idle;
+			unitSprite[unitAction.idle][unitDirection.down] = spr_wizard_front_idle;
+			unitSprite[unitAction.move][unitDirection.right] = spr_wizard_right_walk;
+			unitSprite[unitAction.move][unitDirection.up] = spr_wizard_back_walk;
+			unitSprite[unitAction.move][unitDirection.left] = spr_wizard_left_walk;
+			unitSprite[unitAction.move][unitDirection.down] = spr_wizard_front_walk;
+			unitSprite[unitAction.attack][unitDirection.right] = spr_wizard_right_attack;
+			unitSprite[unitAction.attack][unitDirection.up] = spr_wizard_back_attack;
+			unitSprite[unitAction.attack][unitDirection.left] = spr_wizard_left_attack;
+			unitSprite[unitAction.attack][unitDirection.down] = spr_wizard_front_attack;
+			unitSprite[unitAction.specialAttack][unitDirection.right] = spr_wizard_right_attack;
+			unitSprite[unitAction.specialAttack][unitDirection.up] = spr_wizard_back_attack;
+			unitSprite[unitAction.specialAttack][unitDirection.left] = spr_wizard_left_attack;
+			unitSprite[unitAction.specialAttack][unitDirection.down] = spr_wizard_front_attack;
+			// Actual Sprite Value
+			currentAction = unitAction.idle;
+			currentDirection = unitDirection.right;
+			currentSprite = unitSprite[currentAction][currentDirection];
+			spriteWaitTimer = 0;
+			movementLeaderOrFollowing = noone;
+			mask_index = spr_16_16;
+			// Index speed
+			currentImageIndex = 0;
+			currentImageIndexSpeed = 8 / room_speed;
+			break;
+		// ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED
+		case "Abomination":
+			// Generic variables
+			maxHP = 100;
+			currentHP = maxHP;
+			objectRange = 16 * 4;
+			movementSpeed = 1.5;
+			objectIsRubyUnit = true;
+			// Availability variables
+			objectHasSpecialAbility = true;
+			objectCanUseSpecialAbility = false;
+			objectHasCombatSpecializationAbility = false;
+			objectCanUseCombatSpecializationAbility = false;
+			abominationsCanSacrifice = false;
+			// Combat variables
+			objectCombatAggroRange = 10; // This is half the width of the square in mp_grid unit sizes to detect enemies in, centered on this object
+			objectAttackSpeed = 2 * room_speed;
+			objectAttackSpeedTimer = 0;
+			objectAttackDamage = 30;
+			objectAttackDamageType = "Magic";
+			objectSpecialAttackDamage = 50;
+			objectSpecialAttackDamageType = "Magic";
+			// For resistances, they're multipliers. The closer to 0 the higher resistance it has.
+			// Anything above 1 means it has a negative resistance and takes more damage than normal
+			// from that damage type.
+			objectSlashResistance = 1.25;
+			objectPierceResistance = 1;
+			objectMagicResistance = 0.95;
+			// Sprite setting array
+			unitSprite[unitAction.idle][unitDirection.right] = spr_wizard_right_idle;
+			unitSprite[unitAction.idle][unitDirection.up] = spr_wizard_back_idle;
+			unitSprite[unitAction.idle][unitDirection.left] = spr_wizard_left_idle;
+			unitSprite[unitAction.idle][unitDirection.down] = spr_wizard_front_idle;
+			unitSprite[unitAction.move][unitDirection.right] = spr_wizard_right_walk;
+			unitSprite[unitAction.move][unitDirection.up] = spr_wizard_back_walk;
+			unitSprite[unitAction.move][unitDirection.left] = spr_wizard_left_walk;
+			unitSprite[unitAction.move][unitDirection.down] = spr_wizard_front_walk;
+			unitSprite[unitAction.attack][unitDirection.right] = spr_wizard_right_attack;
+			unitSprite[unitAction.attack][unitDirection.up] = spr_wizard_back_attack;
+			unitSprite[unitAction.attack][unitDirection.left] = spr_wizard_left_attack;
+			unitSprite[unitAction.attack][unitDirection.down] = spr_wizard_front_attack;
+			unitSprite[unitAction.specialAttack][unitDirection.right] = spr_wizard_right_attack;
+			unitSprite[unitAction.specialAttack][unitDirection.up] = spr_wizard_back_attack;
+			unitSprite[unitAction.specialAttack][unitDirection.left] = spr_wizard_left_attack;
+			unitSprite[unitAction.specialAttack][unitDirection.down] = spr_wizard_front_attack;
+			// Actual Sprite Value
+			currentAction = unitAction.idle;
+			currentDirection = unitDirection.right;
+			currentSprite = unitSprite[currentAction][currentDirection];
+			spriteWaitTimer = 0;
+			movementLeaderOrFollowing = noone;
+			mask_index = spr_16_16;
+			// Index speed
+			currentImageIndex = 0;
+			currentImageIndexSpeed = 8 / room_speed;
+			break;
+		// ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED
+		case "Automaton":
+			// Generic variables
+			maxHP = 100;
+			currentHP = maxHP;
+			objectRange = 16 * 4;
+			movementSpeed = 1.5;
+			objectIsRubyUnit = true;
+			// Availability variables
+			objectHasSpecialAbility = true;
+			objectCanUseSpecialAbility = false;
+			objectHasCombatSpecializationAbility = true;
+			objectCanUseCombatSpecializationAbility = false;
+			automatonsCanShocktrooper = false;
+			// Combat variables
+			objectCombatAggroRange = 10; // This is half the width of the square in mp_grid unit sizes to detect enemies in, centered on this object
+			objectAttackSpeed = 2 * room_speed;
+			objectAttackSpeedTimer = 0;
+			objectAttackDamage = 30;
+			objectAttackDamageType = "Magic";
+			objectSpecialAttackDamage = 50;
+			objectSpecialAttackDamageType = "Magic";
+			// For resistances, they're multipliers. The closer to 0 the higher resistance it has.
+			// Anything above 1 means it has a negative resistance and takes more damage than normal
+			// from that damage type.
+			objectSlashResistance = 1.25;
+			objectPierceResistance = 1;
+			objectMagicResistance = 0.95;
+			// Sprite setting array
+			unitSprite[unitAction.idle][unitDirection.right] = spr_wizard_right_idle;
+			unitSprite[unitAction.idle][unitDirection.up] = spr_wizard_back_idle;
+			unitSprite[unitAction.idle][unitDirection.left] = spr_wizard_left_idle;
+			unitSprite[unitAction.idle][unitDirection.down] = spr_wizard_front_idle;
+			unitSprite[unitAction.move][unitDirection.right] = spr_wizard_right_walk;
+			unitSprite[unitAction.move][unitDirection.up] = spr_wizard_back_walk;
+			unitSprite[unitAction.move][unitDirection.left] = spr_wizard_left_walk;
+			unitSprite[unitAction.move][unitDirection.down] = spr_wizard_front_walk;
+			unitSprite[unitAction.attack][unitDirection.right] = spr_wizard_right_attack;
+			unitSprite[unitAction.attack][unitDirection.up] = spr_wizard_back_attack;
+			unitSprite[unitAction.attack][unitDirection.left] = spr_wizard_left_attack;
+			unitSprite[unitAction.attack][unitDirection.down] = spr_wizard_front_attack;
+			unitSprite[unitAction.specialAttack][unitDirection.right] = spr_wizard_right_attack;
+			unitSprite[unitAction.specialAttack][unitDirection.up] = spr_wizard_back_attack;
+			unitSprite[unitAction.specialAttack][unitDirection.left] = spr_wizard_left_attack;
+			unitSprite[unitAction.specialAttack][unitDirection.down] = spr_wizard_front_attack;
+			// Actual Sprite Value
+			currentAction = unitAction.idle;
+			currentDirection = unitDirection.right;
+			currentSprite = unitSprite[currentAction][currentDirection];
+			spriteWaitTimer = 0;
+			movementLeaderOrFollowing = noone;
+			mask_index = spr_16_16;
+			// Index speed
+			currentImageIndex = 0;
+			currentImageIndexSpeed = 8 / room_speed;
+			break;
+		
 		#endregion
 		#region Buildings
 		// ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED
@@ -198,6 +428,8 @@ function initialize_object_data() {
 			
 			// Specific Variables
 			canTrainRubyUnits = false;
+			canTrainAbominations = false;
+			canTrainAutomatons = false;
 			break;
 		#endregion
 	}

--- a/scripts/initialize_stat_data/initialize_stat_data.gml
+++ b/scripts/initialize_stat_data/initialize_stat_data.gml
@@ -257,9 +257,9 @@ function _city_hall() constructor {
 				eUpgradeTree.universal, eUpgradeType.innovation, eUpgradeOrder.two, eUpgradeSibling.noone, 
 				false, 2, false, noone, "City Hall", "Worker", "canBuildThicket", noone, 1, 30, 200, 300, 
 				100, 0);
-	drilling = new _upgrade_options("Drilling", "Allows Workers to mine Rubies", eUpgradeTree.universal,
-				eUpgradeType.special, eUpgradeOrder.three, eUpgradeSibling.a, false, 2, false, noone, 
-				"City Hall", "Worker", "canMineRuby", noone, 1, 45, 0, 0, 800, 0);
+	drilling = new _upgrade_options("Drilling", "Allows Workers to mine Rubies", 
+				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.three, eUpgradeSibling.a, 
+				false, 2, false, noone, "City Hall", "Worker", "canMineRuby", noone, 1, 45, 0, 0, 800, 0);
 	refinement = new _upgrade_options("Refinement", "Upgrades to the third Age, unlocking additional upgrades.", 
 				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.three, eUpgradeSibling.b, 
 				false, 2, false, noone, "City Hall", "Player", "age", "Age Three", 1, 150, 300, 500, 
@@ -308,13 +308,17 @@ function _city_hall() constructor {
 function _temple() constructor {
 	statUpdated = false;
 	specialAbilities = new _upgrade_options("Special Abilities", "Unlocks Ruby Unit Special Abilities and allows them to be used in combat.", 
-				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.one, eUpgradeSibling.noone, 
-				false, 1, true, noone, "Temple", obj_unit, "objectCanUseSpecialAbility", noone, 1, 60, 
+				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.one, eUpgradeSibling.a, 
+				false, 2, true, noone, "Temple", "Ruby", "objectCanUseSpecialAbility", noone, 1, 60, 
+				100, 0, 200, 0);
+	combatSpecialtyAbility = new _upgrade_options("Combat Specialty Ability", "Unlocks the Combat Special Ability for the Ruby Unit chosen in your Combat Specialty skill at game start.", 
+				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.one, eUpgradeSibling.b, 
+				false, 2, true, noone, "Temple", "Ruby", "objectCanUseCombatSpecializationAbility", noone, 1, 60, 
 				100, 0, 200, 0);
 	rubyUnits = new _upgrade_options("Ruby Units", "Allows Ruby Units to be built.", 
 				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.two, eUpgradeSibling.a, 
 				false, 2, false, noone, "Temple", obj_building, "canTrainRubyUnits", noone, 1, 60, 100, 
-				100, 200, 0);
+				100, 200, 50);
 	ordained = new _upgrade_options("Ordained", "Acolyte healing is increased.", 
 				eUpgradeTree.universal, eUpgradeType.innovation, eUpgradeOrder.one, eUpgradeSibling.a, 
 				false, 2, false, noone, "Temple", "Acolyte", "outCombatHealValue and inCombatHealValue", 
@@ -325,16 +329,36 @@ function _temple() constructor {
 				150, 0);
 	enlightened = new _upgrade_options("Enlightened", "Increases the damage of all Ruby Units.", 
 				eUpgradeTree.universal, eUpgradeType.offensive, eUpgradeOrder.one, eUpgradeSibling.noone, 
-				false, 2, false, noone, "Temple", "Abomination and Automaton and Acolyte and Wizard and Warlock and Subverter", 
+				false, 2, false, noone, "Temple", "Abomination and Automaton and Acolyte and Wizard and Warlock and Subverter.", 
 				"objectAttackDamage", noone, 8, 90, 50, 100, 150, 200);
-	hideArmor = new _upgrade_options("Hide Armor", "Increases the slash armor of Wizards and Warlocks", 
+	hideArmor = new _upgrade_options("Hide Armor", "Increases the slash armor of Wizards and Warlocks.", 
 				eUpgradeTree.universal, eUpgradeType.defensive, eUpgradeOrder.one, eUpgradeSibling.a, 
 				false, 2, false, noone, "Temple", "Wizard and Warlock", "objectSlashResistance", noone, 
 				-0.1, 60, 200, 0, 100, 0);
-	cover = new _upgrade_options("Cover", "Increases the pierce armor of Subverters and Acolytes", 
+	cover = new _upgrade_options("Cover", "Increases the pierce armor of Subverters and Acolytes.", 
 				eUpgradeTree.universal, eUpgradeType.defensive, eUpgradeOrder.one, eUpgradeSibling.b, 
 				false, 2, false, noone, "Temple", "Subverter and Acolyte", "objectPierceResistance", noone, 
 				-0.1, 60, 50, 200, 100, 0);
+	abominations = new _upgrade_options("Abominations", "Allows Abominations to be built.", 
+				eUpgradeTree.magic, eUpgradeType.special, eUpgradeOrder.two, eUpgradeSibling.b, 
+				false, 2, false, noone, "Temple", obj_building, "canTrainAbominations", noone, 1, 
+				60, 100, 0, 200, 100);
+	fireLinked = new _upgrade_options("Fire Linked", "Unlockes the Fire Link ability for Wiards, allowing three Wizards to link with each other. The group of Linked Wizards lose the ability to fight normally, but the player gains the ability to choose a location within a large range for all Fire Linked Wizards to attack. The Linked Wizards launch a volley of fireballs at the target location, dealing Magic damage to all enemies within that location. Long shared cooldown for all Linked Wizards.", 
+				eUpgradeTree.magic, eUpgradeType.innovation, eUpgradeOrder.two, eUpgradeSibling.a, 
+				false, 2, false, noone, "Temple", "Wizard", "wizardsCanLink", noone, 1, 90, 50, 
+				0, 50, 100);
+	vitalityLinked = new _upgrade_options("Vitality Linked", "Unlocks the Vitality Link ability for Acolytes, allowing three Acolytes to link with each other. The group of Linked Acolytes lose the ability to fight and heal normally, but the player gains the ability to choose a location within a large range for all Vitality Linked Acolytes to heal. The Linked Acolytes infuse the area with healing magic, healing all friendly units within that location. Long shared cooldown for all Linked Acolytes.", 
+				eUpgradeTree.magic, eUpgradeType.innovation, eUpgradeOrder.two, eUpgradeSibling.b, 
+				false, 2, false, noone, "Temple", "Acolyte", "acolytesCanLink", noone, 1, 90, 50, 
+				0, 50, 100);
+	automatons = new _upgrade_options("Automatons", "Allows Automatons to be built.", 
+				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.two, eUpgradeSibling.b, 
+				false, 2, false, noone, "Temple", obj_building, "canTrainAutomatons", noone, 1, 
+				60, 100, 0, 200, 100);
+	shocktrooper = new _upgrade_options("Shocktrooper", "Unlocks the Shocktrooper ability for Automaton, allowing the player to teleport all Automatons not currently in combat to a location within a wide range of any friendly unit that is in combat. This ability has a long cooldown.", 
+				eUpgradeTree.technology, eUpgradeType.innovation, eUpgradeOrder.two, eUpgradeSibling.noone, 
+				false, 2, false, noone, "Temple", "Automaton", "automatonCanShocktrooper", noone, 1, 90, 
+				100, 0, 100, 200);
 	
 }
 

--- a/scripts/unit_attack/unit_attack.gml
+++ b/scripts/unit_attack/unit_attack.gml
@@ -15,7 +15,7 @@ function unit_attack() {
 				var i;
 				var correct_animation_active_ = false;
 				for (i = 0; i < unitDirection.length; i++) {
-					if currentSprite == workerSprite[currentAction][i] {
+					if currentSprite == unitSprite[currentAction][i] {
 						correct_animation_active_ = true;
 						break;
 					}

--- a/scripts/unit_mine/unit_mine.gml
+++ b/scripts/unit_mine/unit_mine.gml
@@ -18,7 +18,7 @@ function unit_mine() {
 				var i;
 				var correct_animation_active_ = false;
 				for (i = 0; i < unitDirection.length; i++) {
-					if currentSprite == workerSprite[currentAction][i] {
+					if currentSprite == unitSprite[currentAction][i] {
 						correct_animation_active_ = true;
 						break;
 					}


### PR DESCRIPTION
Some big behind-the-scenes changes here.

- I had made an earlier mistake and did not differentiate the difference between normal Ruby Unit Special Skills available to all players, and Ruby Unit and Normal Unit Combat Specialty Skills exclusive to the Technology tree. That has been adjusted, and the reference notes and relevant code reflect that change.
- Universalized the unit sprite variable, to clean up code.

A note:
Most code is incomplete. All incomplete code will be filled naturally as the game mechanics fill out. I am not worried about missing sections of code, as I have laid the groundwork for exactly one method of coding these abilities and skills, and tracking them. By necessity, everything will be completed.