### PR TITLE
Added additional stats and requirements

### DIFF
--- a/notes/ObeliskSkillTree/ObeliskSkillTree.txt
+++ b/notes/ObeliskSkillTree/ObeliskSkillTree.txt
@@ -11,46 +11,47 @@ TIER 2 UPGRADES
 - SPECIAL 1 -	Hardening Mist: Obelisks now provide an armor bonus for all units and 
 		buildings within range.
 MAGICAL UPGRADES
-- CHOOSE TWO OF THE FOLLOWING
-	- SPECIAL 2a -	True Sight: Provides True Sight, revealing all Rogues and Subverters 
+- SPECIAL 2 - Obelisk Specialization: CHOOSE TWO OF THE FOLLOWING
+	- SPECIAL 3a -	True Sight: Provides True Sight, revealing all Rogues and Subverters 
 			within range.
 		- INNOVATION 2a-Lingering Gaze: You retain True Sight on Rogues and Subverters 
 		  revealed by your Obelisks for a short time after they leave the Obelisk's range.
-		- SPECIAL 3a -	Freezing Gaze: All enemy units are slowed while in range of the Obelisk.
-	- SPECIAL 2b -	Demon Sentry: Will summon a Demon when an enemy comes within range. 
+		- SPECIAL 4a -	Freezing Gaze: All enemy units are slowed while in range of the Obelisk.
+	- SPECIAL 3b -	Demon Sentry: Will summon a Demon when an enemy comes within range. 
 			Medium cooldown.
 		- INNOVATION 2b-Awoken: Demons summoned by the Obelisk have increased speed and attack
 		  for a short time after being summoned.
-		- SPECIAL 3b -	Trojan Horse: The Obelisk will summon a small number of Demons if it is
+		- SPECIAL 4b -	Trojan Horse: The Obelisk will summon a small number of Demons if it is
 		  destroyed by an enemy.
-	- SPECIAL 2c -	Soul Link: An Obelisk can link to one unit. Once linked, if that unit would have
+	- SPECIAL 3c -	Soul Link: An Obelisk can link to one unit. Once linked, if that unit would have
 	  been killed, the unit is instead saved from death, set to 1 HP,
 	  teleported to the Obelisk, and the Obelisk is then destroyed. An Obelisk
 	  cannot be linked to a unit if the Obelisk is not at full health.
 		- INNOVATION 2c-Lifeline: Units Soul Linked to Obelisks heal rapidly when not in combat.
-		- SPECIAL 3c -	Gaia's Growth: Buildings within range of the Obelisk slowly heal over time.
+		- SPECIAL 4c -	Gaia's Growth: Buildings within range of the Obelisk slowly heal over time.
 TECHNOLOGY UPGRADES
  - CHOOSE TWO OF THE FOLLOWING
-	- SPECIAL 2a -	True Sight: Provides True Sight, revealing all Rogues and Subverters 
+	- SPECIAL 3a -	True Sight: Provides True Sight, revealing all Rogues and Subverters 
 			within range.
 		- INNOVATION 2a-Lingering Gaze: You retain True Sight on Rogues and Subverters 
 		  revealed by your Obelisks for a short time after they leave the Obelisk's range.
-		- SPECIAL 3a -	Freezing Gaze: All enemy units are slowed while in range of the Obelisk.
-	- SPECIAL 2b -	Waygates: Allows units to teleport between Obelisks.
+		- SPECIAL 4a -	Freezing Gaze: All enemy units are slowed while in range of the Obelisk.
+	- SPECIAL 3b -	Waygates: Allows units to teleport between Obelisks.
 		- INNOVATION 2b-Energizing Field: Units gain a temporary speed boost after teleporting 
 		  using the Obelisk.
-		- SPECIAL 3b -	
-	- SPECIAL 2c -	Lasers: Fires beams of lasers at single targets, dealing high damage over time.
+		- SPECIAL 4b -	Obelisks fully heal units that teleport through them at the cost of their own
+		  HP. This effect stops functioning once the Obelisks involved in the teleport are at 1 HP.
+	- SPECIAL 3c -	Lasers: Fires beams of lasers at single targets, dealing high damage over time.
 		- INNOVATION 2c-Plasma Beam: Laser beam is upgraded to plasma beam, dealing even more 
 		  damage.
-		- SPECIAL 3c -	High Intensity Beam: The Obelisk now ignores the target's magic armor.
+		- SPECIAL 4c -	High Intensity Beam: The Obelisk now ignores the target's magic armor.
 
 TIER 1 UPGRADES
 - INNOVATION 2d-Telescopic Lense: Increases the effect range of Obelisks.
-- SPECIAL 3d -	Mystical Strength: Obelisks now provide an attack bonus for all units and 
+- SPECIAL 5 -	Mystical Strength: Obelisks now provide an attack bonus for all units and 
   buildings within range.
-- SPECIAL 4 -	Mystical Connection: You may now choose one sight target for each Obelisk. 
-  The sight target can only be another Obelisk. A narrow line of Vision is constantly 
+- SPECIAL 6 -	Mystical Connection: You may now choose one sight target for each Obelisk. 
+  The sight target must be be another Obelisk. A narrow line of Vision is constantly 
   provided between the original Obelisk and its sight target. Enemies can see your sight lines.
 - DEFENSIVE 1 -	Obsidian Layering: Increases the armor of the Obelisk.
 

--- a/notes/PlayerAdvancementSkillTree/PlayerAdvancementSkillTree.txt
+++ b/notes/PlayerAdvancementSkillTree/PlayerAdvancementSkillTree.txt
@@ -123,7 +123,7 @@ UNLOCKS TIER 3 UPGRADES
 		  increased to a large amount over a short amount of 
 		  time. The Automaton is unable to move or attack while
 		  channeling this ability.
-	- Protectorates:
+	- Protectorate:
 		- Knights will taunt one unit not attacking it or
 		  another Knight during combat. This taunt ability
 		  is on a long cooldown and forces that unit to attack

--- a/scripts/initialize_object_data/initialize_object_data.gml
+++ b/scripts/initialize_object_data/initialize_object_data.gml
@@ -81,6 +81,7 @@ function initialize_object_data() {
 			currentHP = maxHP;
 			movementSpeed = 1;
 			objectIsRubyUnit = false;
+			objectSightRange = 5 * 16;
 			// Availability variables
 			objectHasSpecialAbility = false;
 			objectCanUseSpecialAbility = false;
@@ -191,6 +192,7 @@ function initialize_object_data() {
 			currentHP = maxHP;
 			movementSpeed = 1.5;
 			objectIsRubyUnit = true;
+			objectSightRange = 7 * 16;
 			// Availability variables
 			objectHasSpecialAbility = true;
 			objectCanUseSpecialAbility = false;
@@ -262,6 +264,7 @@ function initialize_object_data() {
 			currentHP = maxHP;
 			movementSpeed = 1.5;
 			objectIsRubyUnit = true;
+			objectSightRange = 7 * 16;
 			// Availability variables
 			objectHasSpecialAbility = true;
 			objectCanUseSpecialAbility = false;
@@ -323,6 +326,7 @@ function initialize_object_data() {
 			currentHP = maxHP;
 			movementSpeed = 1.5;
 			objectIsRubyUnit = true;
+			objectSightRange = 7 * 16;
 			// Availability variables
 			objectHasSpecialAbility = true;
 			objectCanUseSpecialAbility = false;
@@ -389,6 +393,7 @@ function initialize_object_data() {
 			currentHP = maxHP;
 			movementSpeed = 1.5;
 			objectIsRubyUnit = true;
+			objectSightRange = 7 * 16;
 			// Availability variables
 			objectHasSpecialAbility = true;
 			objectCanUseSpecialAbility = false;
@@ -451,6 +456,7 @@ function initialize_object_data() {
 			currentHP = maxHP;
 			movementSpeed = 1.5;
 			objectIsRubyUnit = true;
+			objectSightRange = 8 * 16;
 			// Availability variables
 			objectHasSpecialAbility = true;
 			objectCanUseSpecialAbility = false;
@@ -517,6 +523,7 @@ function initialize_object_data() {
 			currentHP = maxHP;
 			movementSpeed = 1.5;
 			objectIsRubyUnit = true;
+			objectSightRange = 6 * 16;
 			// Availability variables
 			objectHasSpecialAbility = true;
 			objectCanUseSpecialAbility = false;
@@ -583,6 +590,7 @@ function initialize_object_data() {
 			maxHP = 1500;
 			currentHP = maxHP;
 			populationProvided = 25;
+			objectSightRange = 10 * 16;
 			// The distance at which attacks can used, in pixels
 			objectAttackRange = 16 * 8;
 			canAttack = true;
@@ -621,6 +629,20 @@ function initialize_object_data() {
 			canTrainAbominations = false;
 			canTrainAutomatons = false;
 			break;
+		case "Obelisk":
+			// ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED
+			// In this case, all the generic variables need to be added here, 
+			// in addition to the building specific variable
+			// Generic Variables
+			objectSightRange = 10 * 16;
+			
+			// Specific Variables
+			hardeningMistActive = false;
+			hardeningMistRange = 4 * 16;
+			hardeningMistSlashArmorBonus = -0.1;
+			hardeningMistPierceArmorBonus = -0.1;
+			hardeningMistMagicArmorBonus = -0.1;
+			trueSightActive = false;
 		case "Soul Subjugator":
 			// ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED
 			// In this case, all the generic variables need to be added here, 

--- a/scripts/initialize_stat_data/initialize_stat_data.gml
+++ b/scripts/initialize_stat_data/initialize_stat_data.gml
@@ -1,4 +1,5 @@
 function team_struct(team_) constructor {
+	// ADJUST AS MORE BUILDINGS ARE ADDED
 	cityHall = new _city_hall();
 	temple = new _temple();
 	team = team_;
@@ -16,6 +17,7 @@ function team_struct(team_) constructor {
 	shocktrooperCooldownTimer = 120 * room_speed;
 	shocktrooperCooldown = 0;
 	combatSpecializationChosen = "";
+	
 	obeliskUpgradeOneChosen = "";
 	obeliskUpgradeTwoChosen = "";
 	specialBuildingChosen = "";
@@ -173,7 +175,7 @@ function team_struct(team_) constructor {
 }
 
 function _upgrade_options() constructor {
-	if argument_count != 20 {
+	if argument_count != 23 {
 		show_debug_message(string(argument[0]) + " provides the wrong number of arguments. It is currently providing " + string(argument_count));
 		exit;
 	}
@@ -223,6 +225,14 @@ function _upgrade_options() constructor {
 	upgradeGoldCost = argument[18];
 	// integer - The ruby resource cost to begin the upgrade.
 	upgradeRubyCost = argument[19];
+	// ID or noone - The ID of an object or struct that contains a secondary variable the current upgrade
+	// in question is reliant on. Will be set to noone if none exists.
+	upgradeSecondaryRequirementLocationID = argument[20];
+	// string or noone - The variable located in the ID of the object or struct given above that contains
+	// the value the current upgrade in question is reliant on. Will be set to noone if none exists.
+	upgradeSecondaryRequirementVariable = argument[21];
+	// anything or noone - The value of the secondary variable that the current upgrade in question is
+	// reliant on. Will be set to noone if none exists.
 }
 
 // ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED
@@ -234,367 +244,403 @@ function _city_hall() constructor {
 	discovery = new _upgrade_options("Discovery", "Upgrades to the first Age, unlocking your chosen specialization and additional upgrades.", 
 				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.one, eUpgradeSibling.noone,
 				false, 0, true, spr_discovery_icon, "City Hall", "Player" /*available for the
-				player[i].age struct value, set below.*/, "age", "Age One", 1, 30, 250, 150, 200, 0);
+				player[i].age struct value, set below.*/, "age", "Age One", 1, 30, 250, 150, 200, 0, noone, noone, noone);
 	foundations = new _upgrade_options("Foundations", "Increases the pierce and slash armor of all controlled buildings.", 
 				eUpgradeTree.universal, eUpgradeType.defensive, eUpgradeOrder.one, eUpgradeSibling.noone, 
 				false, 1,  false, noone, "City Hall", obj_building, "objectSlashResistance and objectPierceResistance", 
 				noone, "-0.15 and -0.1" /*resistance is a decimal multiplier between 0 to 1, 0 being full damage
-				resisted and 1 being full damage taken*/, 45, 0, 200, 150, 0);
+				resisted and 1 being full damage taken*/, 45, 0, 200, 150, 0, noone, noone, noone);
 	parapets = new _upgrade_options("Parapets", "Increases the damage of all buildings with offensive capabilities.", 
 				eUpgradeTree.universal, eUpgradeType.offensive, eUpgradeOrder.one, eUpgradeSibling.noone, 
 				false, 1, false, noone, "City Hall", obj_building, "objectAttackDamage", noone, 5, 30, 0, 
-				50, 200, 0);
+				50, 200, 0, noone, noone, noone);
 	farming = new _upgrade_options("Farming", "Unlocks the Farm structure and allows it to be built by Workers.", 
 				eUpgradeTree.universal, eUpgradeType.innovation, eUpgradeOrder.one, eUpgradeSibling.a,
 				false, 1, false, noone, "City Hall", "Worker", "canBuildFarm", noone, 1, 60, 200, 200, 0, 
-				0);
+				0, noone, noone, noone);
 	// Drones is also available on the Storehouse building
 	drones = new _upgrade_options("Drones", "Workers no longer need to drop Food, Wood, or Gold off at Storehouses.", 
 				eUpgradeTree.technology, eUpgradeType.innovation, eUpgradeOrder.one, eUpgradeSibling.b, 
 				false, 1, false, noone, "City Hall", "Worker", "canUseDrones", noone, 1, 30, 50, 50, 250, 
-				0);
+				0, noone, noone, noone);
 	experimentation = new _upgrade_options("Experimentation", "Upgrades to the second Age, unlocking additional upgrades.", 
 				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.two, eUpgradeSibling.noone, 
 				false, 1, false, noone, "City Hall", "Player", "age", "Age Two", 1, 120, 
-				400, 500, 700, 0);
+				400, 500, 700, 0, noone, noone, noone);
 	ramparts = new _upgrade_options("Ramparts", "Further increases the pierce and slash armor of all controlled buildings.", 
 				eUpgradeTree.universal, eUpgradeType.defensive, eUpgradeOrder.two, eUpgradeSibling.noone, 
 				false, 2, false, noone, "City Hall", obj_building, "objectSlashResistance and objectPierceResistance", 
-				noone, "-0.1 and -0.1", 30, 0, 500, 300, 0);
+				noone, "-0.1 and -0.1", 30, 0, 500, 300, 0, noone, noone, noone);
 	thickets = new _upgrade_options("Thickets", "Unlocks the Thicket structure and allows it to be built by Workers.", 
 				eUpgradeTree.universal, eUpgradeType.innovation, eUpgradeOrder.two, eUpgradeSibling.noone, 
 				false, 2, false, noone, "City Hall", "Worker", "canBuildThicket", noone, 1, 30, 200, 300, 
-				100, 0);
+				100, 0, noone, noone, noone);
 	// Drilling is also available on the Storehouse building
 	drilling = new _upgrade_options("Drilling", "Allows Workers to mine Rubies", 
 				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.three, eUpgradeSibling.a, 
-				false, 2, false, noone, "City Hall", "Worker", "canMineRuby", noone, 1, 45, 0, 0, 800, 0);
+				false, 2, false, noone, "City Hall", "Worker", "canMineRuby", noone, 1, 45, 0, 0, 800, 0, noone, noone, noone);
 	refinement = new _upgrade_options("Refinement", "Upgrades to the third Age, unlocking additional upgrades.", 
 				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.three, eUpgradeSibling.b, 
 				false, 2, false, noone, "City Hall", "Player", "age", "Age Three", 1, 150, 300, 500, 
-				500, 200);
+				500, 200, noone, noone, noone);
 	bastion = new _upgrade_options("Bastion", "Further increases the pierce and slash armor of all controlled buildings.", 
 				eUpgradeTree.universal, eUpgradeType.defensive, eUpgradeOrder.three, eUpgradeSibling.noone, 
 				false, 3, false, noone, "City Hall", obj_building, "objectSlashResistance and objectPierceResistance", 
-				noone, "-0.1 and -0.1", 30, 0, 600, 400, 100);
+				noone, "-0.1 and -0.1", 30, 0, 600, 400, 100, noone, noone, noone);
 	shielding = new _upgrade_options("Shielding", "Increases the magic armor of all controlled buildings.", 
 				eUpgradeTree.universal, eUpgradeType.defensive, eUpgradeOrder.four, eUpgradeSibling.noone, 
 				false, 3, false, noone, "City Hall", obj_building, "objectMagicResistance", noone, -0.1, 
-				40, 300, 300, 300, 300);
+				40, 300, 300, 300, 300, noone, noone, noone);
 	ballroom = new _upgrade_options("Ballroom", "Each City Hall and House provides additional population.", 
 				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.three, eUpgradeSibling.c, 
 				false, 3, false, noone, "City Hall", obj_building, "populationProvided", noone, 5, 80, 100, 
-				100, 400, 100);
+				100, 400, 100, noone, noone, noone);
 	mines = new _upgrade_options("Mines", "Unlocks the Mine structure and allows it to be built by Workers", 
 				eUpgradeTree.universal, eUpgradeType.innovation, eUpgradeOrder.three, eUpgradeSibling.a, 
 				false, 3, false, noone, "City Hall", "Worker", "canBuildMine", noone, 1, 45, 200, 200, 
-				400, 300);
+				400, 300, noone, noone, noone);
 	soulSubjugator = new _upgrade_options("Soul Subjugator", "Unlocks the Soul Subjugator structure and allows it to be built by Workers.", 
 				eUpgradeTree.magic, eUpgradeType.innovation, eUpgradeOrder.three, eUpgradeSibling.b, 
 				false, 3, false, noone, "City Hall", "Worker", "canBuildSoulSubjugator", noone, 1, 90, 200, 
-				200, 200, 200);
+				200, 200, 200, noone, noone, noone);
 	ritualGround = new _upgrade_options("Ritual Grounds", "Unlocks the Ritual Grounds structure and allows it to be built by Workers.", 
 				eUpgradeTree.magic, eUpgradeType.innovation, eUpgradeOrder.three, eUpgradeSibling.b, 
 				false, 3, false, noone, "City Hall", "Worker", "canBuildRitualGrounds", noone, 1, 90, 200, 
-				200, 200, 200);
+				200, 200, 200, noone, noone, noone);
 	unholyZiggurat = new _upgrade_options("Unholy Ziggurat", "Unlocks the Unholy Ziggurat structure and allows it to be built by Workers.", 
 				eUpgradeTree.magic, eUpgradeType.innovation, eUpgradeOrder.three, eUpgradeSibling.b, 
 				false, 3, false, noone, "City Hall", "Worker", "canBuildUnholyZiggurat", noone, 1, 90, 200, 
-				200, 200, 200);
+				200, 200, 200, noone, noone, noone);
 	railGun = new _upgrade_options("Rail Gun", "Unlocks the Rail Gun structure and allows it to be built by Workers.", 
 				eUpgradeTree.technology, eUpgradeType.innovation, eUpgradeOrder.three, eUpgradeSibling.b, 
 				false, 3, false, noone, "City Hall", "Worker", "canBuildRailGun", noone, 1, 90, 200, 
-				200, 200, 200);
+				200, 200, 200, noone, noone, noone);
 	stasisField = new _upgrade_options("Stasis Field", "Unlocks the Stasis Field structure and allows it to be built by Workers.", 
 				eUpgradeTree.technology, eUpgradeType.innovation, eUpgradeOrder.three, eUpgradeSibling.b, 
 				false, 3, false, noone, "City Hall", "Worker", "canBuildStasisField", noone, 1, 90, 200, 
-				200, 200, 200);
+				200, 200, 200, noone, noone, noone);
 	launchSite = new _upgrade_options("Launch Site", "Unlocks the Launch Site structure and allows it to be built by Workers.", 
 				eUpgradeTree.technology, eUpgradeType.innovation, eUpgradeOrder.three, eUpgradeSibling.b, 
 				false, 3, false, noone, "City Hall", "Worker", "canBuildLaunchSite", noone, 1, 90, 200, 
-				200, 200, 200);
+				200, 200, 200, noone, noone, noone);
 }
 function _temple() constructor {
 	statUpdated = false;
 	rubyUnits = new _upgrade_options("Ruby Units", "Allows Ruby Units to be built.", 
 				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.one, eUpgradeSibling.noone, 
 				false, 2, false, noone, "Temple", obj_building, "canTrainRubyUnits", noone, 1, 60, 100, 
-				100, 200, 50);
+				100, 200, 50, noone, noone, noone);
 	specialAbilities = new _upgrade_options("Special Abilities", "Unlocks Ruby Unit Special Abilities and allows them to be used in combat.", 
 				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.two, eUpgradeSibling.a, 
 				false, 2, true, noone, "Temple", "Ruby", "objectCanUseSpecialAbility", noone, 1, 60, 
-				100, 0, 200, 0);
+				100, 0, 200, 0, noone, noone, noone);
 	rubyCombatSpecializationAbility = new _upgrade_options("Ruby Combat Specialization Ability", "Unlocks the Combat Specialization Ability for the Ruby Unit chosen in your Combat Specialization skill at game start.", 
 				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.two, eUpgradeSibling.c, 
 				false, 2, true, noone, "Temple", "Ruby", "objectCanUseCombatSpecializationAbility", noone, 1, 60, 
-				100, 0, 200, 0);
+				100, 0, 200, 0, noone, noone, noone);
 	ordained = new _upgrade_options("Ordained", "Acolyte healing is increased.", 
 				eUpgradeTree.universal, eUpgradeType.innovation, eUpgradeOrder.one, eUpgradeSibling.a, 
 				false, 2, false, noone, "Temple", "Acolyte", "outCombatHealValue and inCombatHealValue", 
-				noone, "20 and 2", 45, 150, 0, 150, 0);
+				noone, "20 and 2", 45, 150, 0, 150, 0, noone, noone, noone);
 	swiftFooted = new _upgrade_options("Swift Footed", "Subverters gain additional movement speed.", 
 				eUpgradeTree.universal, eUpgradeType.innovation, eUpgradeOrder.one, eUpgradeSibling.b, 
 				false, 2, false, noone, "Temple", "Subverter", "movementSpeed", noone, 1, 45, 150, 0, 
-				150, 0);
+				150, 0, noone, noone, noone);
 	enlightened = new _upgrade_options("Enlightened", "Increases the damage of all Ruby Units.", 
 				eUpgradeTree.universal, eUpgradeType.offensive, eUpgradeOrder.one, eUpgradeSibling.noone, 
 				false, 2, false, noone, "Temple", "Abomination and Automaton and Acolyte and Wizard and Warlock and Subverter.", 
-				"objectAttackDamage", noone, 8, 90, 50, 100, 150, 200);
+				"objectAttackDamage", noone, 8, 90, 50, 100, 150, 200, noone, noone, noone);
 	hideArmor = new _upgrade_options("Hide Armor", "Increases the slash armor of Wizards and Warlocks.", 
 				eUpgradeTree.universal, eUpgradeType.defensive, eUpgradeOrder.one, eUpgradeSibling.a, 
 				false, 2, false, noone, "Temple", "Wizard and Warlock", "objectSlashResistance", noone, 
-				-0.1, 60, 200, 0, 100, 0);
+				-0.1, 60, 200, 0, 100, 0, noone, noone, noone);
 	cover = new _upgrade_options("Cover", "Increases the pierce armor of Subverters and Acolytes.", 
 				eUpgradeTree.universal, eUpgradeType.defensive, eUpgradeOrder.one, eUpgradeSibling.b, 
 				false, 2, false, noone, "Temple", "Subverter and Acolyte", "objectPierceResistance", noone, 
-				-0.1, 60, 50, 200, 100, 0);
+				-0.1, 60, 50, 200, 100, 0, noone, noone, noone);
 	abominations = new _upgrade_options("Abominations", "Allows Abominations to be built.", 
 				eUpgradeTree.magic, eUpgradeType.special, eUpgradeOrder.two, eUpgradeSibling.b, 
 				false, 2, false, noone, "Temple", obj_building, "canTrainAbominations", noone, 1, 
-				60, 100, 0, 200, 100);
+				60, 100, 0, 200, 100, noone, noone, noone);
 	fireLinked = new _upgrade_options("Fire Linked", "Unlockes the Fire Link ability for Wiards, allowing three Wizards to link with each other. The group of Linked Wizards lose the ability to fight normally, but the player gains the ability to choose a location within a large range for all Fire Linked Wizards to attack. The Linked Wizards launch a volley of fireballs at the target location, dealing Magic damage to all enemies within that location. Long shared cooldown for all Linked Wizards.", 
 				eUpgradeTree.magic, eUpgradeType.innovation, eUpgradeOrder.two, eUpgradeSibling.a, 
 				false, 2, false, noone, "Temple", "Wizard", "wizardsCanLink", noone, 1, 90, 50, 
-				0, 50, 100);
+				0, 50, 100, noone, noone, noone);
 	vitalityLinked = new _upgrade_options("Vitality Linked", "Unlocks the Vitality Link ability for Acolytes, allowing three Acolytes to link with each other. The group of Linked Acolytes lose the ability to fight and heal normally, but the player gains the ability to choose a location within a large range for all Vitality Linked Acolytes to heal. The Linked Acolytes infuse the area with healing magic, healing all friendly units within that location. Long shared cooldown for all Linked Acolytes.", 
 				eUpgradeTree.magic, eUpgradeType.innovation, eUpgradeOrder.two, eUpgradeSibling.b, 
 				false, 2, false, noone, "Temple", "Acolyte", "acolytesCanLink", noone, 1, 90, 50, 
-				0, 50, 100);
+				0, 50, 100, noone, noone, noone);
 	automatons = new _upgrade_options("Automatons", "Allows Automatons to be built.", 
 				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.two, eUpgradeSibling.b, 
 				false, 2, false, noone, "Temple", obj_building, "canTrainAutomatons", noone, 1, 
-				60, 100, 0, 200, 100);
+				60, 100, 0, 200, 100, noone, noone, noone);
 	shocktrooper = new _upgrade_options("Shocktrooper", "Unlocks the Shocktrooper ability for Automaton, allowing the player to teleport all Automatons not currently in combat to a location within a wide range of any friendly unit that is in combat. This ability has a long cooldown.", 
 				eUpgradeTree.technology, eUpgradeType.innovation, eUpgradeOrder.two, eUpgradeSibling.noone, 
 				false, 2, false, noone, "Temple", "Automaton", "automatonCanShocktrooper", noone, 1, 90, 
-				100, 0, 100, 200);
+				100, 0, 100, 200, noone, noone, noone);
 	fireball = new _upgrade_options("Singed Circuit", "Reduces the cooldown for the Wizard's Fireball special ability if it hits 2 or more targets with the area of effect, in addition to the primary target.", 
 				eUpgradeTree.universal, eUpgradeType.innovation, eUpgradeOrder.three, eUpgradeSibling.a, 
 				false, 3, false, noone, "Temple", "Wizard", "singedCircuitActive", noone, 1, 30, 
-				0, 0, 200, 300);
+				0, 0, 200, 300, noone, noone, noone);
 	enslavement = new _upgrade_options("Enslavement", "Warlock's summoned Demons are now permanent summons.", 
 				eUpgradeTree.universal, eUpgradeType.innovation, eUpgradeOrder.three, eUpgradeSibling.b, 
 				false, 3, false, noone, "Temple", "Warlock", "enslavementActive", noone, 1, 30, 
-				0, 0, 200, 300);
+				0, 0, 200, 300, noone, noone, noone);
 	sanctified = new _upgrade_options("Sanctified", "Acolyte's healing is increased.", 
 				eUpgradeTree.universal, eUpgradeType.innovation, eUpgradeOrder.three, eUpgradeSibling.c, 
 				false, 3, false, noone, "Temple", "Acolyte", "objectAttackDamage", noone, 10, 30, 
-				250, 0, 0, 300);
+				250, 0, 0, 300, noone, noone, noone);
 	empowered = new _upgrade_options("Empowered", "Increases the damage and healing of all Ruby Units.", 
 				eUpgradeTree.universal, eUpgradeType.offensive, eUpgradeOrder.two, eUpgradeSibling.noone, 
 				false, 3, false, noone, "Temple", "Ruby", "objectAttackDamage", noone, 5, 60, 
-				50, 350, 250, 300);
+				50, 350, 250, 300, noone, noone, noone);
 	powerPotions = new _upgrade_options("Power Potions", "Increases the damage of Wizards, Warlocks, and Demons summoned by Warlocks.", 
 				eUpgradeTree.universal, eUpgradeType.offensive, eUpgradeOrder.three, eUpgradeSibling.a, 
 				false, 3, false, noone, "Temple", "Wizard and Warlock and Demon", "objectAttackDamage and objectSpecialAttackDamage", 
-				noone, "10 and 5", 45, 50, 200, 100, 175);
+				noone, "10 and 5", 45, 50, 200, 100, 175, noone, noone, noone);
 	preparation = new _upgrade_options("Preparation", "Increases the effectiveness of all Subverter effects on buildings.", 
 				eUpgradeTree.universal, eUpgradeType.offensive, eUpgradeOrder.three, eUpgradeSibling.b, 
 				false, 3, false, noone, "Temple", "Subverter", "objectSpecialAttackDisableDuration", 
-				noone, 15 * room_speed, 45, 0, 200, 100, 175);
+				noone, 15 * room_speed, 45, 0, 200, 100, 175, noone, noone, noone);
 	magicBarrier = new _upgrade_options("Magic Barrier", "Increases the magic armor of all Ruby units.", 
 				eUpgradeTree.universal, eUpgradeType.defensive, eUpgradeOrder.two, eUpgradeSibling.a, 
 				false, 3, false, noone, "Temple", "Ruby", "objectMagicResistance", noone, -0.1, 30, 
-				50, 0, 300, 350);
+				50, 0, 300, 350, noone, noone, noone);
 	thickenedSkin = new _upgrade_options("Thickened Skin", "Increases the slash armor of all Ruby units.", 
 				eUpgradeTree.universal, eUpgradeType.defensive, eUpgradeOrder.two, eUpgradeSibling.b, 
 				false, 3, false, noone, "Temple", "Ruby", "objectSlashResistance", noone, -0.1, 45, 
-				50, 200, 300, 150);
+				50, 200, 300, 150, noone, noone, noone);
 	slowingField = new _upgrade_options("Slowing Field", "Increases the pierce armor of all Ruby units.", 
 				eUpgradeTree.universal, eUpgradeType.defensive, eUpgradeOrder.two, eUpgradeSibling.c, 
 				false, 3, false, noone, "Temple", "Ruby", "objectPierceResistance", noone, -0.1, 45, 
-				150, 150, 200, 150);
+				150, 150, 200, 150, noone, noone, noone);
 	sacrifice = new _upgrade_options("Sacrifice", "Abominations can now be sacrificed at a Temple, which provides the player with the body parts the Abomination was created with. The player can then create Abominations with those body parts, thereby allowing the player to create Abominations with specific body parts.", 
 				eUpgradeTree.magic, eUpgradeType.special, eUpgradeOrder.three, eUpgradeSibling.a, 
 				false, 3, false, noone, "Temple", "Abomination", "abominationsCanSacrifice", noone, 1, 90, 
-				150, 250, 400, 400);
+				150, 250, 400, 400, noone, noone, noone);
 	frankensteins = new _upgrade_options("Frankensteins", "Abominations are now given bonuses depending on the parts they're created with. Each Werewolf part increases the movement speed of the Abomination. Each Robot part increases the damage of the Abomination. Each Ogre part increases the health of the Abomination.", 
 				eUpgradeTree.magic, eUpgradeType.special, eUpgradeOrder.three, eUpgradeSibling.b, 
 				false, 3, false, noone, "Temple", "Abomination", "bodyPartsProvideStats", noone, 1, 90, 
-				300, 0, 500, 400);
+				300, 0, 500, 400, noone, noone, noone);
 	soulwell = new _upgrade_options("Soulwell", "All Ruby units are granted addition health. Ruby units spawned with Soul Subjugator do not spawn with additional health.", 
 				eUpgradeTree.magic, eUpgradeType.special, eUpgradeOrder.three, eUpgradeSibling.c, 
 				false, 3, false, noone, "Temple", "Soul Subjugator", "soulwellActive", noone, 1, 
-				120, 500, 0, 200, 600);
+				120, 500, 0, 200, 600, noone, noone, noone);
 	massEnslavement = new _upgrade_options("Mass Enslavement", "Warlocks now summon 3 Demons at once. The Warlock will not summon additional Demons until all 3 previous Demons are dead.", 
 				eUpgradeTree.magic, eUpgradeType.special, eUpgradeOrder.three, eUpgradeSibling.c, 
 				false, 3, false, noone, "Temple", "Ritual Grounds", "massEnslavementActive", noone, 1, 
-				120, 500, 0, 200, 600);
+				120, 500, 0, 200, 600, noone, noone, noone);
 	cycling = new _upgrade_options("Cycling", "Any unit currently empowered by Unholy Ziggurat can be sacrificed at an Unholy Ziggurat to immediately recharge the Unholy Ziggurat to the charge level it was previously at, minus one charge level. No more than one unit empowered by Unholy Ziggurat may be sacrificed per use.", 
 				eUpgradeTree.magic, eUpgradeType.special, eUpgradeOrder.three, eUpgradeSibling.c, 
 				false, 3, false, noone, "Temple", "Unholy Ziggurat", "cyclingActive", noone, 1, 
-				120, 500, 0, 200, 600);
+				120, 500, 0, 200, 600, noone, noone, noone);
 	blessedAura = new _upgrade_options("Blessed Aura", "Acolytes now increase the movement speed of themselves and all friendly units within range.", 
 				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.four, eUpgradeSibling.a, 
 				false, 3, false, noone, "Temple", "Acolyte", "acolyteBlessedAuraActive", noone, 1, 105, 
-				0, 400, 500, 400);
+				0, 400, 500, 400, noone, noone, noone);
 	searingField = new _upgrade_options("Searing Field", "Acolytes now have greater control over their nano tech and deal constant damage to all enemies within a medium range.", 
 				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.four, eUpgradeSibling.b, 
 				false, 3, false, noone, "Temple", "Acolyte", "acolyteSearingFieldActive", noone, 1, 120, 
-				200, 200, 600, 500);
+				200, 200, 600, 500, noone, noone, noone);
 	// If the Rail Gun is chosen as the Technology tree's final building unlock:
 	handheldRailGun = new _upgrade_options("Handheld Rail Guns", "Rangers are given Handheld Rail Guns. Their shots now over-penetrate targets and deal damage to enemies behind their target. However, their attack speed is reduced.", 
 				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.four, eUpgradeSibling.c, 
 				false, 3, false, noone, "Temple", "Ranger", "rangerHandheldRailGunActive and objectAttackSpeed", noone, "1 and 90", 
 				/*The value "90" in the previous argument is the amount of frames that the objectAttackSpeed is increased by*/
-				120, 200, 400, 600, 400);
+				120, 200, 400, 600, 400, "Player", "specialBuildingChosen", "Rail Gun");
 	// If the Stasis Field is chosen as the Technology tree's final building unlock:
 	revealingStasis = new _upgrade_options("Revealing Stasis", "You reveal any invisible units on the location that your Stasis Field is effecting for its duration.", 
 				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.four, eUpgradeSibling.c, 
 				false, 3, false, noone, "Temple", "Player", "stasisRevealsTargets", noone, 1, 120, 
-				250, 250, 250, 250);
+				250, 250, 250, 250, "Player", "specialBuildingChosen", "Stasis Field");
 	// If the Launch Site is chosen as the Technology tree's final building unlock:
 	droneSwarm = new _upgrade_options("Drone Swarm", "Choose any location on the map to deploy a swarm of Drones to. Drones spawn at your Launch Site, move extremely fast, and deal high damage, but have extremely low health. This ability is on a long cooldown.", 
 				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.four, eUpgradeSibling.c, 
 				false, 3, false, noone, "Temple", "Player", "droneSwarmUnlocked", noone, 1, 120, 
-				400, 300, 900, 500);
+				400, 300, 900, 500, "Player", "specialBuildingChosen", "Launch Site");
 	rechargeableBatteries = new _upgrade_options("Rechargeable Batteries", "Reduces the cooldown of your Shocktrooper ability.", 
 				eUpgradeTree.technology, eUpgradeType.innovation, eUpgradeOrder.four, eUpgradeSibling.noone, 
 				false, 3, false, noone, "Temple", "Player", "shocktrooperCooldownTimer", noone, (45 * room_speed) * -1, 120, 
-				500, 100, 600, 400);
+				500, 100, 600, 400, noone, noone, noone);
 }
 function _laboratory() constructor {
 	alchemy = new _upgrade_options("Alchemy", "Improves the effectiveness of Flasks.", 
 				eUpgradeTree.magic, eUpgradeType.innovation, eUpgradeOrder.one, eUpgradeSibling.noone, 
 				false, 1, false, noone, "Laboratory", "Player", "flaskUpgraded", noone, 1, 60, 
-				200, 200, 200, 0);
+				200, 200, 200, 0, noone, noone, noone);
 	skillful = new _upgrade_options("Skillful", "Improves the effectiveness of basic unit special abilities.", 
 				eUpgradeTree.technology, eUpgradeType.innovation, eUpgradeOrder.one, eUpgradeSibling.noone, 
 				false, 1, false, noone, "Laboratory", "Basic", "objectSpecialAbilityUpgraded", noone, 1, 60, 
-				200, 200, 200, 0);
+				200, 200, 200, 0, noone, noone, noone);
 	fullMetalJacket = new _upgrade_options("Full Metal Jacket", "Increases the damage that all buildings deal.", 
 				eUpgradeTree.universal, eUpgradeType.offensive, eUpgradeOrder.one, eUpgradeSibling.noone, 
 				false, 2, false, noone, "Laboratory", "Building", "objectAttackDamage", noone, 5, 45, 
-				0, 350, 200, 0);
+				0, 350, 200, 0, noone, noone, noone);
 	reinforcement = new _upgrade_options("Reinforcement", "Increases the magic armor of all buildings.", 
 				eUpgradeTree.universal, eUpgradeType.defensive, eUpgradeOrder.one, eUpgradeSibling.noone, 
 				false, 2, false, noone, "Laboratory", "Building", "objectMagicResistance", noone, -0.1, 60, 
-				0, 400, 200, 200);
+				0, 400, 200, 200, noone, noone, noone);
 	improvedMagicks = new _upgrade_options("Improved Magicks", "Increases the area of effect by 1 square for the targeted area when dealing damage with Wizard's Fire Linked ability, or Acolyte's Vitality Linked ability.", 
 				eUpgradeTree.magic, eUpgradeType.innovation, eUpgradeOrder.two, eUpgradeSibling.noone, 
 				false, 2, false, noone, "Laboratory", "Wizard and Acolyte", "aoeLinkedSquareSize", noone, 1, 120, 
-				200, 0, 200, 400);
+				200, 0, 200, 400, noone, noone, noone);
 	chronicEmpowerment = new _upgrade_options("Chronic Empowerment", "Increases the damage of all Automatons upon teleporting with the ability Shocktrooper for a short amount of time.", 
 				eUpgradeTree.technology, eUpgradeType.innovation, eUpgradeOrder.two, eUpgradeSibling.noone, 
 				false, 2, false, noone, "Laboratory", "Shocktrooper", "chronicEmpowermentPossible", noone, 1, 120, 
-				200, 0, 200, 400);
+				200, 0, 200, 400, noone, noone, noone);
 	arcaneWeaponResearch = new _upgrade_options("Arcane Weapon Research", "Increases all magic damage dealt by Ruby units.", 
 				eUpgradeTree.universal, eUpgradeType.offensive, eUpgradeOrder.two, eUpgradeSibling.noone, 
 				false, 3, false, noone, "Laboratory", "Ruby", "arcaneWeaponActive", noone, 1, 180, 
-				400, 500, 600, 600);
+				400, 500, 600, 600, noone, noone, noone);
 	arcaneArmorResearch = new _upgrade_options("Arcane Armor Research", "Increases all Magic armor for Ruby units.", 
 				eUpgradeTree.universal, eUpgradeType.defensive, eUpgradeOrder.two, eUpgradeSibling.noone, 
 				false, 3, false, noone, "Laboratory", "Ruby", "arcaneArmorActive", noone, 1, 180, 
-				600, 500, 400, 600);
+				600, 500, 400, 600, noone, noone, noone);
 }
 function _barracks() constructor {
 	enrage = new _upgrade_options("Enrage", "Unlocks the Berserker's Standard Ability, Enrage.", 
 				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.one, eUpgradeSibling.a, 
 				false, 1, false, noone, "Barracks", "Berserker", "objectCanUseSpecialAbility", noone, 
-				1, 45, 150, 0, 0, 0);
+				1, 45, 150, 0, 0, 0, noone, noone, noone);
 	invisibility = new _upgrade_options("Invisibility", "Unlocks the Rogue's Standard Ability, Invisibility.", 
 				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.one, eUpgradeSibling.b, 
 				false, 1, false, noone, "Barracks", "Rogue", "objectCanUseSpecialAbility", noone, 1, 45, 
-				0, 0, 150, 0);
+				0, 0, 150, 0, noone, noone, noone);
 	rally = new _upgrade_options("Rally", "Unlocks the Soldier's Standard Ability, Rally.", 
 				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.one, eUpgradeSibling.c, 
 				false, 1, false, noone, "Barracks", "Soldier", "objectCanUseSpecialAbility", noone, 1, 45, 
-				0, 150, 0, 0);
+				0, 150, 0, 0, noone, noone, noone);
 	scope = new _upgrade_options("Scope", "Increases the range of Rangers.", 
 				eUpgradeTree.universal, eUpgradeType.offensive, eUpgradeOrder.one, eUpgradeSibling.a, 
 				false, 1, false, noone, "Barracks", "Ranger", "objectAttackRange", noone, 1, 45, 
-				0, 200, 0, 0);
+				0, 200, 0, 0, noone, noone, noone);
 	angerManagement = new _upgrade_options("Anger Management", "Increases the attack damage bonus of Berserker's Enrage ability.", 
 				eUpgradeTree.universal, eUpgradeType.offensive, eUpgradeOrder.one, eUpgradeSibling.b, 
 				false, 1, false, noone, "Barracks", "Berserker", "enrageDamageBonus", noone, 3, 60, 
-				200, 0, 0, 0);
+				200, 0, 0, 0, noone, noone, noone);
 	backstab = new _upgrade_options("Backstab", "Increases the damage of Rogue's Ambush ability.", 
 				eUpgradeTree.universal, eUpgradeType.offensive, eUpgradeOrder.one, eUpgradeSibling.c, 
 				false, 1, false, noone, "Barracks", "Rogue", "ambushBonusDamage", noone, 25, 60, 
-				0, 0, 200, 0);
+				0, 0, 200, 0, noone, noone, noone);
 	resolute = new _upgrade_options("Resolute", "Increases the health of Soldiers and Knights.", 
 				eUpgradeTree.universal, eUpgradeType.defensive, eUpgradeOrder.one, eUpgradeSibling.noone, 
 				false, 1, false, noone, "Barracks", "Soldier and Knight", "maxHP", noone, "75 and 140", 90, 
-				250, 250, 250, 0);
-	// This needs to affect only the single basic unit that was chosen at the beginning of the game by Technology's 
-	// Combat Specialization skill tree option
-	combatSpecialAbilities = new _upgrade_options("Combat Special Abilities", "Unlocks the Combat Special Abilities for the basic unit chosen in your Combat Specialization skill at game start.", 
+				250, 250, 250, 0, noone, noone, noone);
+	// The next option will only appear if the variable given (second to last argument) located in the object
+	// or struct (third to last argument) is equal to the value expected (last argument).
+	rogueCombatSpecialAbilities = new _upgrade_options("Rogue Combat Special Abilities", "Unlocks the Combat Special Abilities for the Rogue.", 
 				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.two, eUpgradeSibling.a, 
-				false, 2, false, noone, "Barracks", "Rogue and Berserker and Knight", "objectCanUseCombatSpecializationAbility", 
-				noone, 1, 150, 50, 100, 0);
+				false, 2, false, noone, "Barracks", "Rogue", "objectCanUseCombatSpecializationAbility", 
+				noone, 1, 150, 50, 100, 0, "Player" /*Located in the player struct for each player*/, 
+				"combatSpecializationChosen", "Stealth");
+	// The next option will only appear if the variable given (second to last argument) located in the object
+	// or struct (third to last argument) is equal to the value expected (last argument).
+	berserkerCombatSpecialAbilities = new _upgrade_options("Berserker Combat Special Abilities", "Unlocks the Combat Special Abilities for the Berserker.", 
+				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.two, eUpgradeSibling.a, 
+				false, 2, false, noone, "Barracks", "Berserker", "objectCanUseCombatSpecializationAbility", 
+				noone, 1, 150, 50, 100, 0, "Player" /*Located in the player struct for each player*/, 
+				"combatSpecializationChosen", "Recklessness");
+	// The next option will only appear if the variable given (second to last argument) located in the object
+	// or struct (third to last argument) is equal to the value expected (last argument).
+	knightCombatSpecialAbilities = new _upgrade_options("Knight Combat Special Abilities", "Unlocks the Combat Special Abilities for the Knight.", 
+				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.two, eUpgradeSibling.a, 
+				false, 2, false, noone, "Barracks", "Knight", "objectCanUseCombatSpecializationAbility", 
+				noone, 1, 150, 50, 100, 0, "Player" /*Located in the player struct for each player*/, 
+				"combatSpecializationChosen", "Protectorate");
 	piercingStrike = new _upgrade_options("Piercing Strike", "Rogues are able to find the weak point in their target's armor when using their Ambush ability. Rogues now ignore a quarter of their target's armor when dealing damage with Ambush.", 
 				eUpgradeTree.universal, eUpgradeType.offensive, eUpgradeOrder.two, eUpgradeSibling.a, 
 				false, 2, false, noone, "Barracks", "Rogue", "piercingStrikeActive", noone, 1, 
-				100, 100, 50, 0);
+				100, 100, 50, 0, noone, noone, noone);
 	stabilizedWeapons = new _upgrade_options("Stabilized Weapons", "Further increases the range of Rangers.", 
 				eUpgradeTree.universal, eUpgradeType.offensive, eUpgradeOrder.two, eUpgradeSibling.b, 
 				false, 2, false, noone, "Barracks", "Ranger", "objectAttackRange", noone, 1, 105, 
-				0, 300, 100, 0);
+				0, 300, 100, 0, noone, noone, noone);
 	moraleBoost = new _upgrade_options("Morale Boost", "Increases the damage bonus for Soldiers when surrounded by other friendly Soldiers.", 
 				eUpgradeTree.universal, eUpgradeType.offensive, eUpgradeOrder.two, eUpgradeSibling.c, 
 				false, 2, false, noone, "Barracks", "Soldier", "courageDamageBonus", noone, 2, 105, 
-				200, 50, 300, 0);
+				200, 50, 300, 0, noone, noone, noone);
 	steelArmor = new _upgrade_options("Steel Armor", "Increases the magic armor of Knights.", 
 				eUpgradeTree.universal, eUpgradeType.defensive, eUpgradeOrder.two, eUpgradeSibling.a, 
 				false, 2, false, noone, "Barracks", "Knight", "objectMagicResistance", noone, -0.10, 120, 
-				100, 300, 300, 0);
+				100, 300, 300, 0, noone, noone, noone);
 	hardenedLeather = new _upgrade_options("Hardened Leather", "Increases the slash armor of Berserkers.", 
 				eUpgradeTree.universal, eUpgradeType.defensive, eUpgradeOrder.two, eUpgradeSibling.b, 
 				false, 2, false, noone, "Barracks", "Berserker", "objectSlashResistance", noone, -0.10, 105, 
-				300, 100, 200, 0);
+				300, 100, 200, 0, noone, noone, noone);
 	flamingArrows = new _upgrade_options("Flaming Arrows", "Rangers now ignite their shots with magic, dealing a small amount of additional damage.", 
 				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.two, eUpgradeSibling.b, 
 				false, 3, false, noone, "Barracks", "Ranger", "objectAttackDamage", noone, 3, 105, 
-				200, 500, 400, 0);
+				200, 500, 400, 0, noone, noone, noone);
 	sharpenedWeapons = new _upgrade_options("Sharpened Weapons", "Increases the damage of all basic units.", 
 				eUpgradeTree.universal, eUpgradeType.offensive, eUpgradeOrder.three, eUpgradeSibling.noone, 
 				false, 3, false, noone, "Barracks", "Basic", "objectAttackDamage", noone, 2, 120, 
-				400, 400, 800, 0);
+				400, 400, 800, 0, noone, noone, noone);
 	chainMail = new _upgrade_options("Chain Mail", "Increases the slash and pierce armor of all basic units.", 
 				eUpgradeTree.universal, eUpgradeType.defensive, eUpgradeOrder.three, eUpgradeSibling.a, 
 				false, 3, false, noone, "Barracks", "Basic", "objectSlashResistance and objectPierceResistance", 
-				noone, "-0.05 and -0.15", 120, 300, 500, 800, 0);
+				noone, "-0.05 and -0.15", 120, 300, 500, 800, 0, noone, noone, noone);
 	blessedArmor = new _upgrade_options("Blessed Armor", "Increases the magic armor of all basic units.", 
 				eUpgradeTree.universal, eUpgradeType.defensive, eUpgradeOrder.three, eUpgradeSibling.b, 
 				false, 3, false, noone, "Barracks", "Basic", "objectMagicResistance", noone, -0.10, 120, 
-				200, 600, 800, 0);
+				200, 600, 800, 0, noone, noone, noone);
 }
 function _storehouse() constructor {
 	trainedWorkers = new _upgrade_options("Trained Workers", "Increases the gathering speed of all basic resources by Workers.", 
 				eUpgradeTree.universal, eUpgradeType.innovation, eUpgradeOrder.one, eUpgradeSibling.a, 
 				false, 1, false, noone, "Storehouse", "Worker", "objectFoodGatherDamage and objectWoodChopDamage and objectGoldMineDamage", 
-				noone, 1, 60, 100, 200, 200, 0);
+				noone, 1, 60, 100, 200, 200, 0, noone, noone, noone);
 	// Drones is also available on the City Hall building
 	drones = new _upgrade_options("Drones", "Workers no longer need to drop Food, Wood, or Gold off at Storehouses.", 
 				eUpgradeTree.technology, eUpgradeType.innovation, eUpgradeOrder.one, eUpgradeSibling.b, 
 				false, 1, false, noone, "Storehouse", "Worker", "canUseDrones", noone, 1, 30, 50, 50, 250, 
-				0);
+				0, noone, noone, noone);
 	advancedTooling = new _upgrade_options("Advanced Tooling", "Further increases the gathering speed of all basic resources by Workers.", 
 				eUpgradeTree.universal, eUpgradeType.innovation, eUpgradeOrder.two, eUpgradeSibling.noone, 
 				false, 2, false, noone, "Storehouse", "Worker", "objectFoodGatherDamage and objectWoodChopDamage and objectGoldMineDamage", 
-				noone, 1, 120, 200, 400, 400, 0);
+				noone, 1, 120, 200, 400, 400, 0, noone, noone, noone);
 	// Drilling is also available on the City Hall building
 	drilling = new _upgrade_options("Drilling", "Allows Workers to mine Rubies", 
 				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.one, eUpgradeSibling.noone, 
-				false, 2, false, noone, "Storehouse", "Worker", "canMineRuby", noone, 1, 45, 0, 0, 800, 0);
+				false, 2, false, noone, "Storehouse", "Worker", "canMineRuby", noone, 1, 45, 0, 0, 800, 0, noone, noone, noone);
 	magicTraining = new _upgrade_options("Magic Training", "Increases the gathering speed of Rubies by Workers.", 
 				eUpgradeTree.universal, eUpgradeType.innovation, eUpgradeOrder.three, eUpgradeSibling.noone, 
 				false, 2, false, noone, "Storehouse", "Worker", "objectRubyMineDamage", noone, 2, 90, 
-				100, 200, 200, 150);
+				100, 200, 200, 150, noone, noone, noone);
 	speedyHands = new _upgrade_options("Speedy Hands", "Further increases the gathering speed of all basic resources by Workers.", 
 				eUpgradeTree.universal, eUpgradeType.innovation, eUpgradeOrder.four, eUpgradeSibling.noone, 
 				false, 3, false, noone, "Storehouse", "Worker", "objectFoodGatherDamage and objectWoodChopDamage and objectGoldMineDamage", 
-				noone, 2, 180, 400, 800, 800, 0);
+				noone, 2, 180, 400, 800, 800, 0, noone, noone, noone);
 	rollerSkates = new _upgrade_options("Roller Skates", "Increases the movement speed of Workers while not in combat.", 
 				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.two, eUpgradeSibling.a, 
 				false, 3, false, noone, "Storehouse", "Worker", "movementSpeedBonusAvailable", noone, 1, 
-				600, 0, 400, 0);
+				600, 0, 400, 0, noone, noone, noone);
 	futuristicTooling = new _upgrade_options("Futuristic Tooling", "When gathering basic resources, Workers have a random chance to obtain additional resources on collection.", 
 				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.two, eUpgradeSibling.a, 
 				false, 3, false, noone, "Storehouse", "Worker", "randomBasicResourceGenerationActive", noone, 1, 
-				600, 600, 600, 400);
+				600, 600, 600, 400, noone, noone, noone);
 }
 function _obelisk() constructor {
+	telescopes = new _upgrade_options("Telescopes", "Increases the sight range of Obelisks.", 
+				eUpgradeTree.universal, eUpgradeType.innovation, eUpgradeOrder.one, eUpgradeSibling.noone, 
+				false, 2, false, noone, "Obelisk", "Obelisk", "objectSightRange", noone, 3 * 16, 
+				200, 200, 200, 0, noone, noone, noone);
+	hardeningMist = new _upgrade_options("Hardening Mist", "Obelisks now provide an armor bonus for all units and buildings within range.", 
+				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.one, eUpgradeSibling.noone, 
+				false, 2, false, noone, "Obelisk", "Obelisk", "hardeningMistActive", noone, 1, 
+				200, 400, 300, 0, noone, noone, noone);
+	// This opens a menu to choose two specializations for the Obelisk building out of three options.
+	// It affects multiple variables, so I include it here really as just a placeholder to make the menu
+	// appear when the talent is clicked.
+	obeliskSpecialization = new _upgrade_options("Obelisk Specialization", "Choose two of the following upgrade tree paths.", 
+				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.two, eUpgradeSibling.noone, 
+				false, 2, false, noone, "Obelisk", "Player", "", "Obelisk Specialization", "", 
+				200, 200, 200, 0, noone, noone, noone);
+	// If True Sight is chosen as one of two upgrades for obeliskSpecialization, listed above
+	trueSight = new _upgrade_options("True Sight", "Provides True Sight, revealing all Rogues and Subverters within range.", 
+				eUpgradeTree.universal, eUpgradeType.special, eUpgradeOrder.three, eUpgradeSibling.a, 
+				false, 2, false, noone, "Obelisk", "Obelisk", "trueSightActive", noone, 1, 
+				100, 400, 400, 0, noone, noone, noone);
+	// If True Sight is chosen as one of two upgrades for obeliskSpecialization, and if it has been acquired
 	
 }
 


### PR DESCRIPTION
Before, the structs in charge of upgrade tracking for objects would be reliant on secondary scripts to track requirements that weren't explicitly listed in the upgrade information and requirement structs. Now, that has been added, so, for example, if an upgrade requires that a previous specific upgrade was acquired, that is now able to be determined right within that same upgrade struct, instead of through a secondary script.