### PR TITLE
Resource drop off works perfectly

### DIFF
--- a/objects/obj_unit/Step_0.gml
+++ b/objects/obj_unit/Step_0.gml
@@ -5,6 +5,28 @@ if !initialized {
 // Depth setting
 depth = -y//(y / 1000);
 
+// Stop certain conditions from being met if the unit isn't a Worker currently working on returning
+// gathered materials to a dropoff point or making its way back from the dropoff point.
+if returnToResourceID != noone {
+	if (objectType == "Worker") && (instance_exists(objectTarget)) {
+		// If the target exists, but it's not a resource or a dropoff point
+		if (objectTarget.objectClassification != "Resource") && ((objectTarget.objectClassification == "Building") && ((objectTarget.objectType != "Farm") && (objectTarget.objectType != "Thicket") && (objectTarget.objectType != "Mine") && (objectTarget.objectType != "City Hall") && (objectTarget.objectType != "Storehouse"))) {
+			set_return_resource_variables_noone();
+		}
+		// If the Worker's current command is not to collect a material
+		if (objectCurrentCommand != "Farm") && (objectCurrentCommand != "Chop") && (objectCurrentCommand != "Mine") && (objectCurrentCommand != "Ruby Mine") {
+			set_return_resource_variables_noone();
+		}
+		// If the Worker's current state is not Idle, Move, or collecting a material
+		if (currentAction != unitAction.idle) && (currentAction != unitAction.move) && (currentAction != unitAction.farm) && (currentAction != unitAction.chop) && (currentAction != unitAction.mine) {
+			set_return_resource_variables_noone();
+		}
+	}
+	else if (objectType == "Worker") && (!instance_exists(objectTarget)) {
+		check_for_new_target(returnToResourceX, returnToResourceY, returnToResourceType);
+	}
+}
+
 // Stop certain sections of code if not on screen
 var top_y_ = y - sprite_get_height(sprite_index) + 16;
 var bottom_y_ = y + 16;
@@ -586,7 +608,7 @@ if !obj_gui.startMenu.active {
 						}
 					}
 				}
-				ds_list_sort_distance(target_list_);
+				ds_list_sort_distance(x, y, target_list_);
 				// If the object at target location is a valid target, then mine/attack it if the
 				// object selected is an object that can mine it. An object's actual "team" 
 				// (objectRealTeam) will only be set to "Neutral" if it is a resource.
@@ -633,7 +655,12 @@ if !obj_gui.startMenu.active {
 								ds_list_add(objectTargetList, object_at_location_);
 							}
 							if !mouse_check_button_pressed(mb_right) || (mouse_check_button_pressed(mb_right) && !objectSelected) {
-								ds_list_sort_distance(objectTargetList);
+								if returnToResourceID == noone {
+									ds_list_sort_distance(x, y, objectTargetList);
+								}
+								else {
+									ds_list_sort_distance(returnToResourceX, returnToResourceY, objectTargetList);
+								}
 							}
 						}
 						else if (object_at_location_.object_index == obj_unit) || (object_at_location_.object_index == obj_building) {
@@ -657,7 +684,7 @@ if !obj_gui.startMenu.active {
 								ds_list_add(objectTargetList, object_at_location_);
 							}
 							if !mouse_check_button_pressed(mb_right) || (mouse_check_button_pressed(mb_right) && !objectSelected) {
-								ds_list_sort_distance(objectTargetList);
+								ds_list_sort_distance(x, y, objectTargetList);
 							}
 						}
 						else {
@@ -684,7 +711,7 @@ if !obj_gui.startMenu.active {
 							ds_list_add(objectTargetList, object_at_location_);
 						}
 						if !mouse_check_button_pressed(mb_right) || (mouse_check_button_pressed(mb_right) && !objectSelected) {
-							ds_list_sort_distance(objectTargetList);
+							ds_list_sort_distance(x, y, objectTargetList);
 						}
 					}
 				}

--- a/scripts/check_for_new_target/check_for_new_target.gml
+++ b/scripts/check_for_new_target/check_for_new_target.gml
@@ -1,43 +1,56 @@
 ///@function				check_for_new_target(x_, y_);
 ///@param	{real}	x_		x_
 ///@param	{real}	y_		y_
+///@param	{string}		optional - the object type looking for
 ///@description				Checks for a new set of targets within range using detect_nearby_enemy_objects() script.
 ///							Called usually after the current list of targets has expired but the object is still in
 ///							combat, meaning there are potentially other, not-yet-found valid targets within range.
 function check_for_new_target(x_, y_) {
-	if detect_nearby_enemy_objects(x_, y_) {
-		if ds_exists(objectDetectedList, ds_type_list) {
-			// If the ds_list for current targets doesn't exist, checked above, but current targets exist
-			// within range, checked in detect_nearby_enemy_objects() script and verified above, then 
-			// copy that list over to the actual target list and then set the nearest enemy target as the
-			// next valid target to attack.
-			if ds_exists(objectTargetList, ds_type_list) {
-				ds_list_destroy(objectTargetList);
-				objectTargetList = noone;
+	// If the object type is provided
+	if argument_count > 2 {
+		var object_type_ = argument[2];
+	}
+	else {
+		var object_type_ = noone;
+	}
+	// If the object type was provided, give that to the script.
+	if object_type_ != noone {
+		detect_nearby_enemy_objects(x_, y_, object_type_);
+	}
+	else {
+		detect_nearby_enemy_objects(x_, y_);
+	}
+	if ds_exists(objectDetectedList, ds_type_list) {
+		// If the ds_list for current targets doesn't exist, checked above, but current targets exist
+		// within range, checked in detect_nearby_enemy_objects() script and verified above, then 
+		// copy that list over to the actual target list and then set the nearest enemy target as the
+		// next valid target to attack.
+		if ds_exists(objectTargetList, ds_type_list) {
+			ds_list_destroy(objectTargetList);
+			objectTargetList = noone;
+		}
+		objectTargetList = ds_list_create();
+		ds_list_copy(objectTargetList, objectDetectedList);
+		ds_list_destroy(objectDetectedList);
+		objectDetectedList = noone;
+		var i, closest_target_, distance_;
+		for (i = 0; i < ds_list_size(objectTargetList); i++) {
+			var instance_to_reference_ = ds_list_find_value(objectTargetList, i);
+			if i == 0 {
+				closest_target_ = real(instance_to_reference_.id);
+				distance_ = point_distance(x_, y_, closest_target_.x, closest_target_.y);
 			}
-			objectTargetList = ds_list_create();
-			ds_list_copy(objectTargetList, objectDetectedList);
-			ds_list_destroy(objectDetectedList);
-			objectDetectedList = noone;
-			var i, closest_target_, distance_;
-			for (i = 0; i < ds_list_size(objectTargetList); i++) {
-				var instance_to_reference_ = ds_list_find_value(objectTargetList, i);
-				if i == 0 {
-					closest_target_ = real(instance_to_reference_.id);
-					distance_ = distance_to_object(closest_target_);
-				}
-				else if distance_to_object(instance_to_reference_) < distance_ {
-					closest_target_ = real(instance_to_reference_.id);
-					distance_ = distance_to_object(closest_target_);
-				}
+			else if distance_to_object(instance_to_reference_) < distance_ {
+				closest_target_ = real(instance_to_reference_.id);
+				distance_ = point_distance(x_, y_, closest_target_.x, closest_target_.y);
 			}
-	
-			objectTarget = closest_target_;
-			var current_target_index_ = ds_list_find_index(objectTargetList, closest_target_);
-			if current_target_index_ != 0 {
-				ds_list_delete(objectTargetList, current_target_index_)
-				ds_list_insert(objectTargetList, 0, closest_target_);
-			}
+		}
+
+		objectTarget = closest_target_;
+		var current_target_index_ = ds_list_find_index(objectTargetList, closest_target_);
+		if current_target_index_ != 0 {
+			ds_list_delete(objectTargetList, current_target_index_)
+			ds_list_insert(objectTargetList, 0, closest_target_);
 		}
 	}
 }

--- a/scripts/detect_nearby_enemy_objects/detect_nearby_enemy_objects.gml
+++ b/scripts/detect_nearby_enemy_objects/detect_nearby_enemy_objects.gml
@@ -1,4 +1,4 @@
-///@function					detect_nearby_enemy_objects();
+///@function					detect_nearby_enemy_objects(x, y, objectType);
 ///@param	{real}	x_			The x value of the location to check
 ///@param	{real}	y_			The y value of the location to check
 ///@param	{string}			optional - the objectType looking for.
@@ -51,13 +51,20 @@ function detect_nearby_enemy_objects(x_, y_) {
 			// at location matches the specified target type, then add that object's ID to the list.
 			if instance_exists(instance_at_location_) {
 				// As long as the nearby object isn't a resource or resource building, continue working.
-				if (instance_at_location_.objectClassification != "Resource") && (instance_at_location_.objectType != "Farm") && (instance_at_location_.objectType != "Thicket") && (instance_at_location_.objectType != "Mine") {
+				// I don't check for resource buildings because they shouldn't automatically be destroyed
+				// by armies, because they're usable by all teams.
+				// Or, if the nearby object is a resource or resource building, and the specified type
+				// of object to look for is a resource or resource building, then continue working.
+				if ((instance_at_location_.objectClassification != "Resource") && (instance_at_location_.objectType != "Farm") && (instance_at_location_.objectType != "Thicket") && (instance_at_location_.objectType != "Mine")) || (((target_specified_ == "Food") && (instance_at_location_.objectType == "Food")) || ((target_specified_ == "Wood") && (instance_at_location_.objectType == "Wood")) || ((target_specified_ == "Gold") && (instance_at_location_.objectType == "Gold")) || ((target_specified_ == "Ruby") && (instance_at_location_.objectType == "Ruby")) || ((target_specified_ == "Farm") && (instance_at_location_.objectType == "Farm")) || ((target_specified_ == "Thicket") && (instance_at_location_.objectType == "Thicket")) || ((target_specified_ == "Mine") && (instance_at_location_.objectType == "Mine"))) {
 					// Specifically check to see if the visible team, AND real team is not equal to the
 					// same team as the object calling this script. This prevents any automatic check from
 					// registering friendly spies who are commanded to look like enemy units, or registering
 					// enemy spies who are commanded to look like friendly units. 
-					if ((instance_at_location_.objectVisibleTeam != objectRealTeam && instance_at_location_.objectRealTeam != objectRealTeam)) {
-						if (!target_specified_) || (instance_at_location_.objectType == target_specified_) {
+					// Also, check to see if the unit calling this script is a Worker, in which case if
+					// its command is to collect resources, then any nearby resources or resource buildings
+					// should be found as well.
+					if ((instance_at_location_.objectVisibleTeam != objectRealTeam) && (instance_at_location_.objectRealTeam != objectRealTeam)) || ((objectType == "Worker") && ((objectCurrentCommand == "Gather") || (objectCurrentCommand == "Chop") || (objectCurrentCommand == "Mine")) && ((instance_at_location_.objectType == "Farm") || (instance_at_location_.objectType == "Thicket") || (instance_at_location_.objectType == "Mine"))) {
+						if (target_specified_ == false) || (instance_at_location_.objectType == target_specified_) {
 							if !ds_exists(objectDetectedList, ds_type_list) {
 								objectDetectedList = ds_list_create();
 							}
@@ -72,7 +79,7 @@ function detect_nearby_enemy_objects(x_, y_) {
 	// careful.
 	if ds_exists(objectDetectedList, ds_type_list) {
 		if ds_list_size(objectDetectedList) > 1 {
-			ds_list_sort_distance(objectDetectedList);
+			ds_list_sort_distance(x, y, objectDetectedList);
 		}
 	}
 	return true;

--- a/scripts/determine_leader_or_follower/determine_leader_or_follower.gml
+++ b/scripts/determine_leader_or_follower/determine_leader_or_follower.gml
@@ -58,7 +58,7 @@ function determine_leader_or_follower() {
 	// Check between all potential leaders, if they exist, and determine which is closest to move with.
 	// Otherwise, set self as leader.
 	if ds_exists(leader_objects_list_, ds_type_list) {
-		ds_list_sort_distance(leader_objects_list_);
+		ds_list_sort_distance(x, y, leader_objects_list_);
 		movementLeaderOrFollowing = ds_list_find_value(leader_objects_list_, 0);
 		validPathFound = true;
 		ds_list_destroy(leader_objects_list_);

--- a/scripts/ds_list_sort_distance/ds_list_sort_distance.gml
+++ b/scripts/ds_list_sort_distance/ds_list_sort_distance.gml
@@ -1,8 +1,10 @@
-///@function									ds_list_sort_distance();
+///@function									ds_list_sort_distance(x, y, DSListToSorty);
+///@param	{real} x							The X location to search from.
+///@param	{real} y							The Y location to search from.
 ///@param	{real} DSListToSort					The ds_list to sort.
-///@description									Sort objects in a ds_list by distance, in pixels, relative to the object
-///												calling this function. Only works with objects.
-function ds_list_sort_distance(original_list_) {
+///@description									Sort objects in a ds_list by distance, in pixels, relative to the location
+///												given (generally the object calling this function). Only works with objects.
+function ds_list_sort_distance(x_, y_, original_list_) {
 	// After the target_list_ is created, go through and sort that list by closest to furthest,
 	// with closest being at index 0.
 	if ds_exists(original_list_, ds_type_list) {
@@ -14,7 +16,7 @@ function ds_list_sort_distance(original_list_) {
 				for (current_ = total_; current_ < ds_list_size(original_list_); current_++) {
 					var instance_to_reference_ = ds_list_find_value(original_list_, current_);
 					if instance_exists(instance_to_reference_) {
-						var distance_to_referenced_instance_ = distance_to_object(instance_to_reference_);
+						var distance_to_referenced_instance_ = point_distance(x_, y_, instance_to_reference_.x, instance_to_reference_.y);
 						if furthest_object_ == noone {
 							furthest_object_ = instance_to_reference_;
 							longest_distance_ = distance_to_referenced_instance_;

--- a/scripts/initialize_object_data/initialize_object_data.gml
+++ b/scripts/initialize_object_data/initialize_object_data.gml
@@ -111,6 +111,7 @@ function initialize_object_data() {
 			returnToResourceX = noone;
 			returnToResourceY = noone;
 			returnToResourceID = noone;
+			returnToResourceType = noone;
 			objectHasSpecialAbility = false;
 			objectCanUseSpecialAbility = false;
 			objectSpecialAbilityUpgraded = false;

--- a/scripts/set_return_resource_variables/set_return_resource_variables.gml
+++ b/scripts/set_return_resource_variables/set_return_resource_variables.gml
@@ -10,7 +10,8 @@ function set_return_resource_variables(x_, y_, instance_id_) {
 	if objectClassification == "Unit" && objectType == "Worker" {
 		returnToResourceX = x_;
 		returnToResourceY = y_;
-		returnToResourceID = instance_id_;
+		returnToResourceID = real(instance_id_);
+		returnToResourceType = instance_id_.objectType;
 	}
 }
 
@@ -22,6 +23,7 @@ function set_return_resource_variables_noone() {
 	returnToResourceX = noone;
 	returnToResourceY = noone;
 	returnToResourceID = noone;
+	returnToResourceType = noone;
 }
 
 

--- a/scripts/unit_mine/unit_mine.gml
+++ b/scripts/unit_mine/unit_mine.gml
@@ -31,6 +31,7 @@ function unit_mine() {
 					}
 				}
 				if correct_animation_active_ {
+					set_return_resource_variables_noone();
 					switch object_type_ {
 						case "Food":
 							if objectFoodGatherSpeedTimer <= 0 {
@@ -98,7 +99,7 @@ function unit_mine() {
 							}
 							break;
 						case "Mine":
-							if objectGoldMineSpeedTimer <= 0 {
+						if objectGoldMineSpeedTimer <= 0 {
 								objectGoldMineSpeedTimer = objectGoldMineSpeed;
 								player[objectRealTeam].gold += objectGoldMineDamage * (0.8);
 							}
@@ -139,9 +140,9 @@ function unit_mine() {
 			currentRubyCarry = 0;
 			currentResourceWeightCarry = 0;
 			objectTarget = returnToResourceID;
+			objectTargetType = returnToResourceType;
 			targetToMoveToX = returnToResourceX;
 			targetToMoveToY = returnToResourceY;
-			set_return_resource_variables_noone();
 			objectNeedsToMove = true;
 			currentAction = unitAction.move;
 			// Run this script to determine if it should be making its own path, or following the path
@@ -167,7 +168,23 @@ function unit_mine() {
 	}
 	// Check to see if the Worker is maxed out by weight, and if so, move to deposit resources
 	// into a Storehouse.
-	if (object_type_ == "Food" && ((objectFoodGatherDamage * obj_food_resource.foodWeight) > (maxResourceWeightCanCarry - currentResourceWeightCarry))) {
+	var remaining_weight_available_ = maxResourceWeightCanCarry - currentResourceWeightCarry;
+	var resource_gather_weight_ = noone;
+	switch object_type_ {
+		case "Food":
+			resource_gather_weight_ = objectFoodGatherDamage * obj_food_resource.foodWeight;
+			break;
+		case "Wood":
+			resource_gather_weight_ = objectWoodChopDamage * obj_tree_resource.woodWeight;
+			break;
+		case "Gold":
+			resource_gather_weight_ = objectGoldMineDamage * obj_gold_resource.goldWeight;
+			break;
+		case "Ruby":
+			resource_gather_weight_ = objectRubyMineDamage * obj_ruby_resource.rubyWeight;
+			break;
+	}
+	if (resource_gather_weight_ > remaining_weight_available_) && (resource_gather_weight_ != noone) {
 		// Set a variable up to set the current resource target as the 
 		// target to move to after the Worker deposits the resources
 		// held. If the Worker ends up executing any action or commanded
@@ -175,7 +192,7 @@ function unit_mine() {
 		// needs to be wiped.
 		set_return_resource_variables(objectTarget.x, objectTarget.y, real(objectTarget.id));
 		objectNeedsToMove = true;
-		ds_list_sort_distance(player[objectRealTeam].listOfStorehousesAndCityHalls);
+		ds_list_sort_distance(x, y, player[objectRealTeam].listOfStorehousesAndCityHalls);
 		objectTarget = real(ds_list_find_value(player[objectRealTeam].listOfStorehousesAndCityHalls, 0));
 		targetToMoveToX = objectTarget.x;
 		targetToMoveToY = objectTarget.y;

--- a/scripts/unit_move/unit_move.gml
+++ b/scripts/unit_move/unit_move.gml
@@ -51,7 +51,7 @@ function target_next_object() {
 				}
 			}
 			else {
-				objectCurrentCommand = "Move";
+			objectCurrentCommand = "Move";
 				targetToMoveToX = originalTargetToMoveToX;
 				targetToMoveToY = originalTargetToMoveToY;
 				squareIteration = 0;
@@ -89,7 +89,7 @@ function target_next_object() {
 	}
 	else {
 		if objectCurrentCommand == "Attack" {
-			check_for_new_target(x, y);
+		check_for_new_target(x, y);
 		}
 	}
 	if !ds_exists(objectTargetList, ds_type_list) {
@@ -288,6 +288,24 @@ function unit_move() {
 			// be there, or there are no previous objects registered, period, then reset
 			// the variables and exit script.
 			if (!ds_did_not_exist_) || ((originally_self_is_found_ == noone) && (original_location_is_valid_)) {
+				if objectType == "Worker" {
+					if objectCurrentCommand == "Move" {
+						if ds_exists(player[objectRealTeam].listOfStorehousesAndCityHalls, ds_type_list) {
+							ds_list_sort_distance(x, y, player[objectRealTeam].listOfStorehousesAndCityHalls);
+							if distance_to_object(real(ds_list_find_value(player[objectRealTeam].listOfStorehousesAndCityHalls, 0))) < 16 {
+								player[objectRealTeam].food += currentFoodCarry;
+								player[objectRealTeam].wood += currentWoodCarry;
+								player[objectRealTeam].gold += currentGoldCarry;
+								player[objectRealTeam].rubies += currentRubyCarry;
+								currentFoodCarry = 0;
+								currentWoodCarry = 0;
+								currentGoldCarry = 0;
+								currentRubyCarry = 0;
+								currentResourceWeightCarry = 0;
+							}
+						}
+					}
+				}
 				changeVariablesWhenCloseToTarget = true;
 				notAtTargetLocation = false;
 				validLocationFound = true;
@@ -320,7 +338,7 @@ function unit_move() {
 				movementLeaderOrFollowing = noone;
 				if path_exists(myPath) {
 					path_delete(myPath);
-					myPath = -1;
+				myPath = -1;
 				}
 				if objectCurrentCommand == "Move" {
 					objectCurrentCommand = "Idle";
@@ -1089,6 +1107,24 @@ function unit_move() {
 									if (ds_exists(objectTargetList, ds_type_list)) && (instance_exists(objectTarget)) {
 										// If the ranged object is already in range of target, don't move! It can act already.
 										if point_distance(x, y, targetToMoveToX, targetToMoveToY) <= objectAttackRange {
+											if objectType == "Worker" {
+												if objectCurrentCommand == "Move" {
+													if ds_exists(player[objectRealTeam].listOfStorehousesAndCityHalls, ds_type_list) {
+														ds_list_sort_distance(x, y, player[objectRealTeam].listOfStorehousesAndCityHalls);
+														if distance_to_object(real(ds_list_find_value(player[objectRealTeam].listOfStorehousesAndCityHalls, 0))) < 16 {
+															player[objectRealTeam].food += currentFoodCarry;
+															player[objectRealTeam].wood += currentWoodCarry;
+															player[objectRealTeam].gold += currentGoldCarry;
+															player[objectRealTeam].rubies += currentRubyCarry;
+															currentFoodCarry = 0;
+															currentWoodCarry = 0;
+															currentGoldCarry = 0;
+															currentRubyCarry = 0;
+															currentResourceWeightCarry = 0;
+														}
+													}
+												}
+											}
 											changeVariablesWhenCloseToTarget = true;
 											notAtTargetLocation = false;
 											validLocationFound = true;
@@ -1181,7 +1217,7 @@ function unit_move() {
 												currentAction = unitAction.idle;
 											}
 											else if objectCurrentCommand == "Attack" {
-												currentAction = unitAction.attack;
+											currentAction = unitAction.attack;
 											}
 											else if objectCurrentCommand == "Mine" {
 												currentAction = unitAction.mine;
@@ -2183,6 +2219,24 @@ function unit_move() {
 			// speed during two frames, just teleport the object to that location and reset ALL
 			// variables.
 			else {
+				if objectType == "Worker" {
+					if objectCurrentCommand == "Move" {
+						if ds_exists(player[objectRealTeam].listOfStorehousesAndCityHalls, ds_type_list) {
+							ds_list_sort_distance(x, y, player[objectRealTeam].listOfStorehousesAndCityHalls);
+							if distance_to_object(real(ds_list_find_value(player[objectRealTeam].listOfStorehousesAndCityHalls, 0))) < 16 {
+								player[objectRealTeam].food += currentFoodCarry;
+								player[objectRealTeam].wood += currentWoodCarry;
+								player[objectRealTeam].gold += currentGoldCarry;
+								player[objectRealTeam].rubies += currentRubyCarry;
+								currentFoodCarry = 0;
+								currentWoodCarry = 0;
+								currentGoldCarry = 0;
+								currentRubyCarry = 0;
+								currentResourceWeightCarry = 0;
+							}
+						}
+					}
+				}
 				changeVariablesWhenCloseToTarget = true;
 				notAtTargetLocation = false;
 				validLocationFound = true;
@@ -2298,7 +2352,7 @@ function unit_move() {
 		}
 	}
 	// Else if its at target location, then exit script.
-	else {
+else {
 		if ds_exists(unitGridLocation, ds_type_grid) {
 			var i, self_is_found_;
 			self_is_found_ = noone;
@@ -2335,6 +2389,24 @@ function unit_move() {
 			ds_grid_set(unitGridLocation, 0, 0, self.id);
 			ds_grid_set(unitGridLocation, 1, 0, targetToMoveToX);
 			ds_grid_set(unitGridLocation, 2, 0, targetToMoveToY);
+		}
+		if objectType == "Worker" {
+			if objectCurrentCommand == "Move" {
+				if ds_exists(player[objectRealTeam].listOfStorehousesAndCityHalls, ds_type_list) {
+					ds_list_sort_distance(x, y, player[objectRealTeam].listOfStorehousesAndCityHalls);
+					if distance_to_object(real(ds_list_find_value(player[objectRealTeam].listOfStorehousesAndCityHalls, 0))) < 16 {
+						player[objectRealTeam].food += currentFoodCarry;
+						player[objectRealTeam].wood += currentWoodCarry;
+						player[objectRealTeam].gold += currentGoldCarry;
+						player[objectRealTeam].rubies += currentRubyCarry;
+						currentFoodCarry = 0;
+						currentWoodCarry = 0;
+						currentGoldCarry = 0;
+						currentRubyCarry = 0;
+						currentResourceWeightCarry = 0;
+					}
+				}
+			}
 		}
 		changeVariablesWhenCloseToTarget = true;
 		notAtTargetLocation = false;


### PR DESCRIPTION
- Expanded some internal scripts to take additional arguments, to be more flexible.
- Got Resource Dropoffs working completely.
    - Workers will collect resources when commanded, drop off resources when having a full inventory at the nearest drop off point, and then return to continue collecting the same type of resource.
        - This works even when a Worker's original resource node is depleted and destroyed while it's in transit to a drop off point.
        - This works even when a Worker's original resource node is depleted and destroyed while it's currently collecting from it.
        - Workers can be commanded to approach a drop off point. If they are carrying any resources when they come within range, they will automatically drop those resources off.
        - Workers will not automatically drop resources off if they simply walk within range of a drop off point without being commanded to drop off resources, either through specific automatic cases as listed above, or by the player. This is by design.