### PR TITLE
Updating stats and internals

### DIFF
--- a/Pride of Pixels.resource_order
+++ b/Pride of Pixels.resource_order
@@ -163,6 +163,7 @@
     {"name":"spr_worker_left_farm","order":2,"path":"sprites/spr_worker_left_farm/spr_worker_left_farm.yy",},
     {"name":"line_of_sight","order":11,"path":"scripts/line_of_sight/line_of_sight.yy",},
     {"name":"spr_robot_legs_back_attack","order":3,"path":"sprites/spr_robot_legs_back_attack/spr_robot_legs_back_attack.yy",},
+    {"name":"SpecialBuildingSkillTrees","order":14,"path":"notes/SpecialBuildingSkillTrees/SpecialBuildingSkillTrees.yy",},
     {"name":"spr_robot_chest_left_walk","order":2,"path":"sprites/spr_robot_chest_left_walk/spr_robot_chest_left_walk.yy",},
     {"name":"spr_acolyte_left_walk","order":2,"path":"sprites/spr_acolyte_left_walk/spr_acolyte_left_walk.yy",},
     {"name":"spr_robot_legs_back_walk","order":3,"path":"sprites/spr_robot_legs_back_walk/spr_robot_legs_back_walk.yy",},

--- a/Pride of Pixels.yyp
+++ b/Pride of Pixels.yyp
@@ -394,6 +394,7 @@
     {"id":{"name":"spr_worker_left_farm","path":"sprites/spr_worker_left_farm/spr_worker_left_farm.yy",},},
     {"id":{"name":"line_of_sight","path":"scripts/line_of_sight/line_of_sight.yy",},},
     {"id":{"name":"spr_robot_legs_back_attack","path":"sprites/spr_robot_legs_back_attack/spr_robot_legs_back_attack.yy",},},
+    {"id":{"name":"SpecialBuildingSkillTrees","path":"notes/SpecialBuildingSkillTrees/SpecialBuildingSkillTrees.yy",},},
     {"id":{"name":"spr_robot_chest_left_walk","path":"sprites/spr_robot_chest_left_walk/spr_robot_chest_left_walk.yy",},},
     {"id":{"name":"spr_worker_front_walk","path":"sprites/spr_worker_front_walk/spr_worker_front_walk.yy",},},
     {"id":{"name":"spr_acolyte_left_walk","path":"sprites/spr_acolyte_left_walk/spr_acolyte_left_walk.yy",},},

--- a/notes/PlayerAdvancementSkillTree/PlayerAdvancementSkillTree.txt
+++ b/notes/PlayerAdvancementSkillTree/PlayerAdvancementSkillTree.txt
@@ -62,11 +62,13 @@ UNLOCKS TIER 1 UPGRADES
 	  slain ally within a massive range and give them a second 
 	  chance at life, respawning them. Will not activate if the
 	  respawned unit would exceed the player's Population cap.
-		- All units are granted additional health. Units
+		- Lifewell: All units are granted additional health. Units
+		  respawned with Soul Subjugator lose this effect. (faint green
+		  swirling beams, kind of like northern lights, around each
+		  unit occasionally appear).
+		- Special Available Upgrade: Soulwell: All ruby units
+		  are granted additional health on spawn. Ruby units
 		  respawned with Soul Subjugator lose this effect.
-			Special Available Upgrade: Soulwell: All ruby units 
-			are granted additional health on spawn. Ruby units 
-			respawned with Soul Subjugator lose this effect.
 	- Ritual Grounds: Requires a Warlock within range to activate.
 	  Continuously spawns Demons that are Soulbound to the nearest
 	  Warlock. If that Warlock dies, the Demons will follow suite
@@ -74,10 +76,11 @@ UNLOCKS TIER 1 UPGRADES
 	  Soulbound Warlock and will die if they are out of range.
 	  Demons do not take up Population. A maximum of 20 Demons
 	  summoned by Ritual Grounds can be active at any point.
-		- All Demons are empowered, and gain additional damage.
-			Special Available Upgrade: Mass Enslavement: Warlocks 
-			now summon 3 Demons at once. The Warlock will not summon 
-			more Demons until all 3 are dead.
+		- Strength of Xul: All Demons are empowered, and gain additional 
+		  damage. (flame behind attack swings animation)
+		- Special Available Upgrade: Mass Enslavement: Warlocks 
+		  now summon 3 Demons at once. The Warlock will not summon 
+		  more Demons until all 3 are dead.
 	- Unholy Ziggurat: Requires units to be sacrificed at the
 	  Unholy Ziggurat to charge up. Can reach 3 different charge
 	  levels at 5, 10, and 20 sacrifices. Unholy Ziggurat can be
@@ -87,12 +90,14 @@ UNLOCKS TIER 1 UPGRADES
 	  level increases the effects of the power up. Unholy Ziggurat
 	  cannot power up other units or locations within the time frame
 	  of the currently active power up.
-		- Grants additional movement speed to all units of the same 
-		  type that was last sacrificed at Unholy Ziggurat.
-			Special Available Upgrade: Any unit currently empowered 
-			by Unholy Ziggurat can be sacrificed at an Unholy Ziggurat 
-			to immediately recharge the Unholy Ziggurat to the charge 
-			level it was previously at, minus one charge level.
+		- Profane Speed: Grants additional movement speed to all units of the same 
+		  type that was last sacrificed at Unholy Ziggurat. (green fog at the 
+		  feet of the units affected by this, leaves behind slight trail of quickly 
+		  fading fog).
+		- Special Available Upgrade: Cycling: Any unit currently empowered 
+		  by Unholy Ziggurat can be sacrificed at an Unholy Ziggurat 
+		  to immediately recharge the Unholy Ziggurat to the charge 
+		  level it was previously at, minus one charge level.
  - Abominations can be sacrificed at a Temple for body parts, and then
    those body parts can be used to custom build Abominations with their
    own stats. Each body part provides a different boost to stats.

--- a/notes/SpecialBuildingSkillTrees/SpecialBuildingSkillTrees.txt
+++ b/notes/SpecialBuildingSkillTrees/SpecialBuildingSkillTrees.txt
@@ -1,0 +1,23 @@
+FIRST TIER
+- SPECIAL 1a -	Lifewell: IF SOUL SUBJUGATOR CHOSEN: All units are granted additional health on spawn. Units
+		respawned with Soul Subjugator lose this effect.
+- SPECIAL 1b -	Soulwell: IF SOUL SUBJUGATOR CHOSEN: All ruby units are granted additional health on spawn. 
+		Ruby units respawned with Soul Subjugator lose this effect.
+
+
+- SPECIAL 1a -	Strength of Xul: IF RITUAL GROUNDS CHOSEN: All demons are empowered, and gain additional damage.
+- SPECIAL 1b -	Mass Enslavement: IF RITUAL GROUNDS CHOSEN: Warlocks now summon 3 Demons at once. The Warlock
+		will not summon more Demons until all 3 are dead.
+
+- SPECIAL 1a -	Profane Speed: IF UNHOLY ZIGGURAT CHOSEN: Grants additional movement speed to all units of
+		the same type that was last sacrificed to the Unholy Ziggurat.
+- SPECIAL 1b -	Cycling: IF UNHOLY ZIGGURAT CHOSEN: Any unit currently empowered by Unholy Ziggurat can be
+		sacrificed at an Unholy Ziggurat to immediately recharge the Unholy Ziggurat to the
+		charge level it was previously at, minus one charge level.
+		
+		
+I do not include the last tier of Technology tree buildings, because the variables set there are player
+variables, since they're mostly powers that can be used globally, and are not just powers that affect
+a specific unit or set of units like the Magic tree buildings.
+
+

--- a/notes/SpecialBuildingSkillTrees/SpecialBuildingSkillTrees.yy
+++ b/notes/SpecialBuildingSkillTrees/SpecialBuildingSkillTrees.yy
@@ -1,0 +1,9 @@
+{
+  "resourceType": "GMNotes",
+  "resourceVersion": "1.1",
+  "name": "SpecialBuildingSkillTrees",
+  "parent": {
+    "name": "Notes",
+    "path": "folders/Notes.yy",
+  },
+}

--- a/notes/TempleSkillTree/TempleSkillTree.txt
+++ b/notes/TempleSkillTree/TempleSkillTree.txt
@@ -56,13 +56,6 @@ MAGICAL UPGRADES
 		Each Werewolf part increases the movement speed of Abominations. Each Robot part
 		increases the damage of Abominations. Each Ogre part increases the health of
 		Abominations.
-- SPECIAL 4c -	Soulwell: IF SOUL SUBJUGATOR CHOSEN: All ruby units are granted additional health on spawn. 
-		Ruby units respawned with Soul Subjugator lose this effect.
-- SPECIAL 4c -	Mass Enslavement: IF RITUAL GROUNDS CHOSEN: Warlocks now summon 3 Demons at once. The Warlock
-		will not summon more Demons until all 3 are dead.
-- SPECIAL 4c -	Cycling: IF UNHOLY ZIGGURAT CHOSEN: Any unit currently empowered by Unholy Ziggurat can be
-		sacrificed at an Unholy Ziggurat to immediately recharge the Unholy Ziggurat to the
-		charge level it was previously at, minus one charge level.
 TECHNOLOGY UPGRADES
 - SPECIAL 4a -	Blessed Aura: Acolytes now increase the movement speed of all friendly units within range.
 - SPECIAL 4b -	Searing Field: Acolytes now have greater control over their nano tech and deal constant damage

--- a/notes/UnitsAbilities/UnitsAbilities.txt
+++ b/notes/UnitsAbilities/UnitsAbilities.txt
@@ -30,9 +30,9 @@ AN OVERVIEW OF ALL UNITS, WHAT THEY DO, AND THEIR ABILITIES.
 -		3. IF MAGIC:
 			- Flask of Speed: Increases the movement speed of all units.
 	}
-	UNIVERSALLY AVAILABLE
--	Morale Boost: Temporarily increase the damage of all nearby friendly Soldiers, not including
-				  itself. This buff can stack.
+-	1. UNIVERSALLY AVAILABLE
+-		- Morale Boost: Temporarily increase the damage of all nearby friendly units, not including
+		itself. This buff can stack.
 	
 	
 -	Ranger
@@ -48,10 +48,23 @@ AN OVERVIEW OF ALL UNITS, WHAT THEY DO, AND THEIR ABILITIES.
 	}
 	IF TECH TREE
 	Togglable Ability, ON/OFF
--	Handheld Rail Gun: Rangers are given Handheld Rail Guns. Their shots now over-penetrate targets 
-	and deal damage to enemies behind their target. However, their attack speed is reduced.
+-	1. IF TECH
+		- Handheld Rail Gun: Rangers are given Handheld Rail Guns. Their shots now over-penetrate targets 
+		  and deal damage to enemies behind their target. However, their attack speed is reduced.
 	
 -	Knight
+-	The tanking melee unit. High defense stats, decent offensive combat stats. Deals damage in an area of
+	effect whenever it attacks.
+	-	Abilities:
+	{	-	CAN ONLY CHOOSE ONE OF THESE
+-		1. IF MAGIC
+			- Flask of Stoneskin: Increases the armor of all units.
+-		2. IF MAGIC:
+			- Flask of Power: Temporarily boosts all unit's damage.
+-		3. IF MAGIC:
+			- Flask of Speed: Increases the movement speed of all units.
+	}
+	
 
 -	Rogue
 

--- a/objects/obj_unit/Create_0.gml
+++ b/objects/obj_unit/Create_0.gml
@@ -41,6 +41,9 @@ beingTargetedByWizardRedirect = false;
 wizardApplyingRedirect = noone;
 damageBeingRedirectedTo = noone;
 
+/// Unholy Ziggurat Variables
+canBeSacrificedToUnholyZiggurat = true;
+
 /// Variable used to attack friendly targets if the player or AI commands it.
 // Can only be set by the player, always false by default.
 forceAttack = false;

--- a/scripts/initialize_object_data/initialize_object_data.gml
+++ b/scripts/initialize_object_data/initialize_object_data.gml
@@ -204,6 +204,12 @@ function initialize_object_data() {
 			// Index speed
 			currentImageIndex = 0;
 			currentImageIndexSpeed = 8 / room_speed;
+			
+			/// Specific Variables
+			profaneSpeedActive = false;
+			// Profane speed should be ADDED to the unit's movement speed
+			profaneSpeedMovementBonus = 0.15;
+			lifewellActive = false;
 			break;
 			
 		
@@ -264,6 +270,12 @@ function initialize_object_data() {
 			// Index speed
 			currentImageIndex = 0;
 			currentImageIndexSpeed = 8 / room_speed;
+			
+			/// Specific variables
+			profaneSpeedActive = false;
+			// Profane speed should be ADDED to the unit's movement speed
+			profaneSpeedMovementBonus = 0.15;
+			lifewellActive = false;
 			break;
 		// ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED
 		case "Soldier":
@@ -320,6 +332,12 @@ function initialize_object_data() {
 			// Index speed
 			currentImageIndex = 0;
 			currentImageIndexSpeed = 8 / room_speed;
+			
+			/// Specific variables
+			profaneSpeedActive = false;
+			// Profane speed should be ADDED to the unit's movement speed
+			profaneSpeedMovementBonus = 0.15;
+			lifewellActive = false;
 			break;
 		case "Knight":
 			// Generic variables
@@ -379,6 +397,12 @@ function initialize_object_data() {
 			// Index speed
 			currentImageIndex = 0;
 			currentImageIndexSpeed = 8 / room_speed;
+			
+			/// Specific variables
+			profaneSpeedActive = false;
+			// Profane speed should be ADDED to the unit's movement speed
+			profaneSpeedMovementBonus = 0.15;
+			lifewellActive = false;
 			break;
 		case "Ranger":
 			// Generic variables
@@ -435,6 +459,12 @@ function initialize_object_data() {
 			// Index speed
 			currentImageIndex = 0;
 			currentImageIndexSpeed = 8 / room_speed;
+			
+			/// Specific variables
+			profaneSpeedActive = false;
+			// Profane speed should be ADDED to the unit's movement speed
+			profaneSpeedMovementBonus = 0.15;
+			lifewellActive = false;
 			break;
 		// ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED
 		case "Rogue":
@@ -499,6 +529,12 @@ function initialize_object_data() {
 			// Index speed
 			currentImageIndex = 0;
 			currentImageIndexSpeed = 8 / room_speed;
+			
+			/// Specific variables
+			profaneSpeedActive = false;
+			// Profane speed should be ADDED to the unit's movement speed
+			profaneSpeedMovementBonus = 0.15;
+			lifewellActive = false;
 			break;
 		// ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED
 		case "Wizard":
@@ -591,6 +627,13 @@ function initialize_object_data() {
 			// Index speed
 			currentImageIndex = 0;
 			currentImageIndexSpeed = 8 / room_speed;
+			
+			/// Specific variables
+			profaneSpeedActive = false;
+			// Profane speed should be ADDED to the unit's movement speed
+			profaneSpeedMovementBonus = 0.15;
+			lifewellActive = false;
+			soulwellActive = false;
 			break;
 		// ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED
 		case "Warlock":
@@ -672,6 +715,13 @@ function initialize_object_data() {
 			// Index speed
 			currentImageIndex = 0;
 			currentImageIndexSpeed = 8 / room_speed;
+			
+			/// Specific variables
+			profaneSpeedActive = false;
+			// Profane speed should be ADDED to the unit's movement speed
+			profaneSpeedMovementBonus = 0.15;
+			lifewellActive = false;
+			soulwellActive = false;
 			break;
 		// ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED
 		case "Demon":
@@ -712,10 +762,10 @@ function initialize_object_data() {
 			// Demon dies at the end of the countdown.
 			summonedDemonsDeathTimer = 4 * room_speed;
 			// The range at which Demons will run back to their master's sides no matter what their current action was. Set by
-			// the Warlock's parent variable by the same name.
+			// the Warlock's parent variable by the same name, so this is by default set to -1.
 			summonedDemonsMaxTetherRange = -1;
 			// Demons will immediately die if they exceed this distance from their master, no matter their current action. Set by
-			// the Warlock's parent variable by the same name.
+			// the Warlock's parent variable by the same name, so this are by default set to -1.
 			summonedDemonsMaxDeathRange = -1;
 			// For resistances, they're multipliers. The closer to 0 the higher resistance it has.
 			// Anything above 1 means it has a negative resistance and takes more damage than normal
@@ -723,7 +773,7 @@ function initialize_object_data() {
 			objectSlashResistance = 1.25;
 			objectPierceResistance = 1.25;
 			objectMagicResistance = 0.75;
-			// Sprite setting array
+			/// Sprite setting array
 			unitSprite[unitAction.idle][unitDirection.right] = spr_demon_right_idle;
 			unitSprite[unitAction.idle][unitDirection.up] = spr_demon_back_idle;
 			unitSprite[unitAction.idle][unitDirection.left] = spr_demon_left_idle;
@@ -736,7 +786,7 @@ function initialize_object_data() {
 			unitSprite[unitAction.attack][unitDirection.up] = spr_demon_back_attack;
 			unitSprite[unitAction.attack][unitDirection.left] = spr_demon_left_attack;
 			unitSprite[unitAction.attack][unitDirection.down] = spr_demon_front_attack;
-			// Actual Sprite Value
+			/// Actual Sprite Value
 			currentAction = unitAction.idle;
 			currentDirection = unitDirection.right;
 			currentSprite = unitSprite[currentAction][currentDirection];
@@ -746,9 +796,19 @@ function initialize_object_data() {
 			spriteWaitTimer = 0;
 			movementLeaderOrFollowing = noone;
 			mask_index = spr_16_16;
-			// Index speed
+			/// Index speed
 			currentImageIndex = 0;
 			currentImageIndexSpeed = 8 / room_speed;
+			
+			/// Specific variables
+			// This is a standard variable for obj_unit, but I set it to false here because I do not want
+			// players sacrificing Demons to the Unholy Ziggurat, since they're free units.
+			canBeSacrificedToUnholyZiggurat = false;
+			profaneSpeedActive = false;
+			// Profane speed should be ADDED to the unit's movement speed
+			profaneSpeedMovementBonus = 0.15;
+			lifewellActive = false;
+			soulwellActive = false;
 			break;
 		// ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED
 		case "Acolyte":
@@ -824,6 +884,13 @@ function initialize_object_data() {
 			// Index speed
 			currentImageIndex = 0;
 			currentImageIndexSpeed = 8 / room_speed;
+			
+			/// Special variables
+			profaneSpeedActive = false;
+			// Profane speed should be ADDED to the unit's movement speed
+			profaneSpeedMovementBonus = 0.15;
+			lifewellActive = false;
+			soulwellActive = false;
 			break;
 		// ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED
 		case "Subverter":
@@ -886,6 +953,13 @@ function initialize_object_data() {
 			// Index speed
 			currentImageIndex = 0;
 			currentImageIndexSpeed = 8 / room_speed;
+			
+			/// Specific variables
+			profaneSpeedActive = false;
+			// Profane speed should be ADDED to the unit's movement speed
+			profaneSpeedMovementBonus = 0.15;
+			lifewellActive = false;
+			soulwellActive = false;
 			break;
 		// ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED
 		case "Abomination":
@@ -1069,6 +1143,13 @@ function initialize_object_data() {
 			// Index speed
 			currentImageIndex = 0;
 			currentImageIndexSpeed = 8 / room_speed;
+			
+			/// Specific variables
+			profaneSpeedActive = false;
+			// Profane speed should be ADDED to the unit's movement speed
+			profaneSpeedMovementBonus = 0.15;
+			lifewellActive = false;
+			soulwellActive = false;
 			break;
 		// ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED
 		case "Automaton":
@@ -1146,6 +1227,9 @@ function initialize_object_data() {
 			// Index speed
 			currentImageIndex = 0;
 			currentImageIndexSpeed = 8 / room_speed;
+			
+			/// Special variables
+			
 			break;
 		
 		#endregion
@@ -1301,6 +1385,10 @@ function initialize_object_data() {
 			canTrainRubyUnits = false;
 			canTrainAbominations = false;
 			canTrainAutomatons = false;
+			headRecycled = "";
+			chestRecycled = "";
+			legsRecycled = "";
+			bodyPartsAddedToTemple = false;
 			break;
 		case "Obelisk":
 			// ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED
@@ -1418,7 +1506,10 @@ function initialize_object_data() {
 			mp_grid_add_instances(movementGrid, self, true);
 			
 			// Specific Variables
+			lifewellActive = false;
+			lifewellHealthBonus = 50;
 			soulwellActive = false;
+			soulwellHealthBonus = 75;
 			break;
 		case "Ritual Grounds":
 			// Generic variables
@@ -1454,6 +1545,8 @@ function initialize_object_data() {
 			
 			// Specific Variables
 			massEnslavementActive = false;
+			strengthOfXulActive = false;
+			strengthOfXulDamageBonus = 4;
 			break;
 		case "Unholy Ziggurat":
 			// Generic variables
@@ -1489,10 +1582,8 @@ function initialize_object_data() {
 			
 			// Specific Variables
 			cyclingActive = false;
-			headRecycled = "";
-			chestRecycled = "";
-			legsRecycled = "";
-			bodyPartsAddedToTemple = false;
+			profaneSpeedActive = false;
+			lastUnitTypeSacrificed = "";
 			break;
 		case "Rail Gun":
 			/// ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED

--- a/scripts/initialize_stat_data/initialize_stat_data.gml
+++ b/scripts/initialize_stat_data/initialize_stat_data.gml
@@ -162,8 +162,8 @@ function _upgrade_options() constructor {
 	upgradeSibling = argument[5];
 	// boolean - Whether the upgrade is active
 	upgradeActive = argument[6]
-	// boolean - Whether the upgrade is currently being unlocked.
-	upgradeBeingUnlocked = false;
+			// boolean - Whether the upgrade is currently being unlocked.
+			upgradeBeingUnlocked = false;
 	// integer - The age requirement for the upgrade to be unlocked, beginning at age 0.
 	upgradeAgeRequirement = argument[7]
 	// boolean - Whether the upgrade is available to unlock.
@@ -406,18 +406,6 @@ function _temple() constructor {
 				eUpgradeTree.magic, eUpgradeType.special, eUpgradeOrder.four, eUpgradeSibling.b, 
 				false, 3, false, noone, "Temple", "Abomination", "bodyPartsProvideStats", noone, 1, 90, 
 				300, 0, 500, 400, noone, noone, noone);
-	soulwell = new _upgrade_options("Soulwell", "All Ruby units are granted addition health. Ruby units spawned with Soul Subjugator do not spawn with additional health.", 
-				eUpgradeTree.magic, eUpgradeType.special, eUpgradeOrder.four, eUpgradeSibling.c, 
-				false, 3, false, noone, "Temple", "Soul Subjugator", "soulwellActive", noone, 1, 
-				120, 500, 0, 200, 600, noone, noone, noone);
-	massEnslavement = new _upgrade_options("Mass Enslavement", "Warlocks now summon 3 Demons at once. The Warlock will not summon additional Demons until all 3 previous Demons are dead.", 
-				eUpgradeTree.magic, eUpgradeType.special, eUpgradeOrder.four, eUpgradeSibling.c, 
-				false, 3, false, noone, "Temple", "Ritual Grounds", "massEnslavementActive", noone, 1, 
-				120, 500, 0, 200, 600, noone, noone, noone);
-	cycling = new _upgrade_options("Cycling", "Any unit currently empowered by Unholy Ziggurat can be sacrificed at an Unholy Ziggurat to immediately recharge the Unholy Ziggurat to the charge level it was previously at, minus one charge level. No more than one unit empowered by Unholy Ziggurat may be sacrificed per use.", 
-				eUpgradeTree.magic, eUpgradeType.special, eUpgradeOrder.four, eUpgradeSibling.c, 
-				false, 3, false, noone, "Temple", "Unholy Ziggurat", "cyclingActive", noone, 1, 
-				120, 500, 0, 200, 600, noone, noone, noone);
 	blessedAura = new _upgrade_options("Blessed Aura", "Acolytes now increase the movement speed of themselves and all friendly units within range.", 
 				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.four, eUpgradeSibling.a, 
 				false, 3, false, noone, "Temple", "Acolyte", "acolyteBlessedAuraActive", noone, 1, 105, 
@@ -470,7 +458,7 @@ function _laboratory() constructor {
 				200, 0, 200, 400, noone, noone, noone);
 	chronicEmpowerment = new _upgrade_options("Chronic Empowerment", "Increases the damage of all Automatons upon teleporting with the ability Shocktrooper for a short amount of time.", 
 				eUpgradeTree.technology, eUpgradeType.innovation, eUpgradeOrder.two, eUpgradeSibling.noone, 
-				false, 2, false, noone, "Laboratory", "Shocktrooper", "chronicEmpowermentPossible", noone, 1, 120, 
+				false, 2, false, noone, "Laboratory", "Automaton", "chronicEmpowermentPossible", noone, 1, 120, 
 				200, 0, 200, 400, noone, noone, noone);
 	arcaneWeaponResearch = new _upgrade_options("Arcane Weapon Research", "Increases all magic damage and healing dealt by all Ruby units.", 
 				eUpgradeTree.universal, eUpgradeType.offensive, eUpgradeOrder.two, eUpgradeSibling.noone, 
@@ -815,7 +803,36 @@ function _wall() constructor {
 				false, 3, false, noone, "Wall", "Wall", "magicWallsActive", noone, 1, 75, 
 				0, 500, 400, 200, noone, noone, noone);
 }
-
+function _soul_subjugator() constructor {
+	lifewell = new _upgrade_options("Lifewell", "All units are granted additional health. Units spawned with Soul Subjugator do not spawn with additional health.",
+				eUpgradeTree.magic, eUpgradeType.special, eUpgradeOrder.one, eUpgradeSibling.a,
+				false, 3, false, noone, "Soul Subjugator", "Soul Subjugator", "lifewellActive", noone, 1, 
+				90, 500, 300, 200, 300, noone, noone, noone);
+	soulwell = new _upgrade_options("Soulwell", "All Ruby units are granted addition health. Ruby units spawned with Soul Subjugator do not spawn with additional health.", 
+				eUpgradeTree.magic, eUpgradeType.special, eUpgradeOrder.one, eUpgradeSibling.b, 
+				false, 3, false, noone, "Soul Subjugator", "Soul Subjugator", "soulwellActive", noone, 1, 
+				60, 500, 0, 200, 600, noone, noone, noone);
+}
+function _ritual_grounds() constructor {
+	strengthOfXul = new _upgrade_options("Strength of Xul", "All Demons are empowered, and gain additional damage.", 
+				eUpgradeTree.magic, eUpgradeType.special, eUpgradeOrder.one, eUpgradeSibling.a,
+				false, 3, false, noone, "Ritual Grounds", "Ritual Grounds", "strengthOfXulActive", noone, 1,
+				45, 500, 300, 200, 300, noone, noone, noone);
+	massEnslavement = new _upgrade_options("Mass Enslavement", "Warlocks now summon 3 Demons at once. The Warlock will not summon additional Demons until all 3 previous Demons are dead.", 
+				eUpgradeTree.magic, eUpgradeType.special, eUpgradeOrder.one, eUpgradeSibling.b, 
+				false, 3, false, noone, "Ritual Grounds", "Ritual Grounds", "massEnslavementActive", noone, 1, 
+				60, 500, 0, 200, 600, noone, noone, noone);
+}
+function _unholy_ziggurat() constructor {
+	profaneSpeed = new _upgrade_options("Profane Speed", "Grants additional movement speed to all units of the same type that was last sacrificed to the Unholy Ziggurat.",
+				eUpgradeTree.magic, eUpgradeType.special, eUpgradeOrder.one, eUpgradeSibling.a, 
+				false, 3, false, noone, "Unholy Ziggurat", "Unholy Ziggurat", "profaneSpeedActive", noone, 1, 
+				45, 500, 300, 200, 300, noone, noone, noone);
+	cycling = new _upgrade_options("Cycling", "Any unit currently empowered by Unholy Ziggurat can be sacrificed at an Unholy Ziggurat to immediately recharge the Unholy Ziggurat to the charge level it was previously at, minus one charge level. No more than one unit empowered by Unholy Ziggurat may be sacrificed per use.", 
+				eUpgradeTree.magic, eUpgradeType.special, eUpgradeOrder.one, eUpgradeSibling.b, 
+				false, 3, false, noone, "Unholy Ziggurat", "Unholy Ziggurat", "cyclingActive", noone, 1, 
+				60, 500, 0, 200, 600, noone, noone, noone);
+}
 
 /*
 	ADJUST AS MORE UNITS AND/OR BUILDINGS ARE ADDED


### PR DESCRIPTION
Added 3 upgrades available that were in the notes as upgrades available but weren't actually included - "Lifewell", "Strength of Xul", and "Profane Speed".

Added upgrade constructors for the Soul Subjugator, Ritual Grounds, and Unholy Ziggurat buildings (available to the Magic tree only).

Changed upgrades that used to appear on Temple but applied to the aforementioned buildings to now appear on the aforementioned buildings instead.