### PR TITLE
adjusted syntax and added differentiations between abilities

### DIFF
--- a/notes/BarracksSkillTree/BarracksSkillTree.txt
+++ b/notes/BarracksSkillTree/BarracksSkillTree.txt
@@ -22,7 +22,7 @@ TIER 2 UPGRADES
 - DEFENSIVE 2a -Steel Armor: Upgrades the magic armor of Knights.
 - DEFENSIVE 2b -Hardened Leather: Slightly upgrades the slash and pierce armor of Berserkers.
 TECHNOLOGY UPGRADES
-- SPECIAL 2a -	Combat Special Abilities: Unlocks the Combat Special Abilities for the basic
+- SPECIAL 2a -	Combat Specialization Abilities: Unlocks the Combat Specialization Abilities for the basic
 		unit chosen in your Combat Specialization skill at game start.
 
 TIER 1 UPGRADES

--- a/notes/PlayerAdvancementSkillTree/PlayerAdvancementSkillTree.txt
+++ b/notes/PlayerAdvancementSkillTree/PlayerAdvancementSkillTree.txt
@@ -109,37 +109,41 @@ TECHNOLOGY
 THIRD TIER - CHOSEN AT GAME CREATION
 UNLOCKS TIER 3 UPGRADES
  Can build Automatons
- Combat Specialization
+ Combat Specialization Abilities
  - Choose between:
-	- Stealth:
-		- Rogues will remain invisible if they kill an enemy with
-		  an attack boosted by the damage of Stealth. This boosted
-		  damage attack is called Ambush, and is always active
-		  while the Rogue is invisible.
-		- Subverter are equipped with explosives and can be
-		  commanded to explode, dealing massive damage within
-		  a short range to all units and buildings. Destroys
-		  the Subverter in the process.
-	- Recklessness:
-		- Berserkers will leap at their target if not within
-		  attacking range, dealing damage to their target upon
-		  landing.
-		- Automatons can release a wave of Tachyon particles,
-		  dealing small constant damage initially to all units
-		  and buildings in range, with the damage then being
-		  increased to a large amount over a short amount of 
-		  time. The Automaton is unable to move or attack while
-		  channeling this ability.
-	- Protectorate:
-		- Knights can be commanded to encase themselves in a thin
-		  layer of nanobots. Enemies must first break through the
-		  nanobot layer in order to damage the Knight, effectively
-		  providing a temporary boost to the Knight's health.
-		- Wizards can be commanded to protect a unit
-		  automatically selected in combat and redirect part
-		  of the damage taken by that unit for a short duration 
-		  to a Knight if one is in range. If no Knight is
-		  within range, the damage is redirected to the Wizard.
+	- Stealth (Rogues and Subverters):
+		Invisibility:
+			- Rogues will remain invisible if they kill an enemy with
+			  Ambush.
+		Explode:
+			- Subverter are equipped with explosives and can be
+			  commanded to explode, dealing massive damage within
+			  a short range to all units and buildings. Destroys
+			  the Subverter in the process.
+	- Recklessness (Berserkers and Automatons):
+		Reckless Leap:
+			- Berserkers will leap at their target if not within
+			  attacking range, dealing damage to their target upon
+			  landing.
+		Tachyon Bombardment:
+			- Automatons can release a wave of Tachyon particles,
+			  dealing small constant damage initially to all units
+			  and buildings in range, with the damage then being
+			  increased to a large amount over a short amount of 
+			  time. The Automaton is unable to move or attack while
+			  channeling this ability.
+	- Protectorate (Knights and Wizards):
+		Nanobot Encasement:
+			- Knights can be commanded to encase themselves in a thin
+			  layer of nanobots. Enemies must first break through the
+			  nanobot layer in order to damage the Knight, effectively
+			  providing a temporary boost to the Knight's health.
+		Redirect:
+			- Wizards can be commanded to protect a unit
+			  automatically selected in combat and redirect part
+			  of the damage taken by that unit for a short duration 
+			  to a Knight if one is in range. If no Knight is
+			  within range, the damage is redirected to the Wizard.
 
 SECOND TIER
 UNLOCKS TIER 2 UPGRADES

--- a/notes/TempleSkillTree/TempleSkillTree.txt
+++ b/notes/TempleSkillTree/TempleSkillTree.txt
@@ -27,9 +27,7 @@ MAGICAL UPGRADES
 		units within that location.
 TECHNOLOGY UPGRADES
 - SPECIAL 2b -	Automatons: Allows Automatons to be built.
-- SPECIAL 2c -	Ruby Combat Special Abilities: Unlocks the Combat Special Ability for the ruby unit chosen 
-				in your Combat Specialization skill at game start.
-- SPECIAL 3 -	Combat Special Abilities: Unlocks the Combat Special Abilities for the ruby
+- SPECIAL 3 -	Combat Specialization Abilities: Unlocks the Combat Specialization Ability for the ruby
 		unit chosen in your Combat Specialization skill at game start.
 - INNOVATION 2 -Shocktroopers: Unlocks the Shocktroopers ability for Automatons, allowing the player to
 		teleport all Automatons not currently in combat to a location within range

--- a/notes/UnitsAI/UnitsAI.txt
+++ b/notes/UnitsAI/UnitsAI.txt
@@ -66,12 +66,15 @@ Rogue:
 	- Invisibility:
 		- Active ability, toggle with Right Click to turn on Auto Acast
 			- While toggled, shimmering gold border around the icon.
-			- Casts if outside of combat. Lasts until unit takes damage or deals damage.
+			- Casts if outside of combat.
+				- If the Rogue deals damage, Invisibility is cancelled.
+				- If the Rogue takes damage, Invisibility is cancelled.
 	- Ambush:
 		- Active ability, toggle with Right Click to turn on Auto Cast
 			- While toggled, shimmering gold border around the icon.
-			- Casts if in combat, the Rogue is currently in or outside of combat, and the Rogue is
-			  within attack range.
+			- Casts if in combat, the Rogue is currently in or outside of combat, the Rogue is
+			  within attack range, and the Rogue is currently Invisible.
+				- Automatically applied to any attack made while Invisible if unlocked.
 	- (TECH ONLY) 
 
 Ranger:

--- a/notes/UnitsAbilities/UnitsAbilities.txt
+++ b/notes/UnitsAbilities/UnitsAbilities.txt
@@ -78,15 +78,16 @@ ___________
 			- Shielding Aura: An ability that provides a large boost to the resistances of all friendly units 
 			  within range for a short duration.
 	-	3. IF TECH
-			- Protectorate (Combat Special Ability - Basic Unit): Knight can be commanded to encase themselves
-			  in a thin layer of nanobots. Enemies must first break through the nanobot layer in order to damage
-			  the Knight, effectively providing a temporary boost to the Knight's health.
+			- Nanobot Encasement (Combat Specialization Ability - Protectorate - Basic Unit): Knights can be 
+			  commanded to encase themselves in a thin layer of nanobots. Enemies must first break through the 
+			  nanobot layer in order to damage the Knight, effectively providing a temporary boost to the 
+			  Knight's health.
 	
 
 -	Rogue
--	The stealth unit. Low defense stats, extremely high damage.
-	Can become Invisible. Any attacks made while Invisible are considered an Ambush attack, which deals
-	massive damage and removes Invisibility from the Rogue.
+-	The invisible stealth unit. Low defense stats, extremely high damage.
+	Can become Invisible. Can be upgraded to count any attacks made while Invisible to be considered an Ambush 
+	attack, which deals massive damage and removes Invisibility from the Rogue.
 -	Abilities:
 		{	-	CAN ONLY CHOOSE ONE OF THESE
 	-		1. IF MAGIC
@@ -104,8 +105,8 @@ ___________
 			- Ambush: While Invisible, any attack made by the Rogue is considered an Ambush attack. This
 			  deals massive bonus damage to their target, and removes the Rogue from Invisibility.
 	-	3. IF TECH
-			- Stealth (Combat Special Ability - Basic Unit): Rogues will remain Invisible if they kill an
-			  enemy using Ambush while Invisible.
+			- Assassin (Combat Specialization Ability - Stealth - Basic Unit): Rogues will remain Invisible 
+			  if they kill an enemy using Ambush while Invisible.
 
 
 -	Berserker
@@ -124,8 +125,8 @@ ___________
 			- Enrage: The Berserker enters an enraged state, massively increasing it's own damage for a
 			  short amount of time.
 	-	2. IF TECH
-			- Recklessness (Combat Special Ability - Basic Unit): The Berserker will leap at it's target
-			  if it is not within attacking range, dealing damage to it's target.
+			- Reckless Leap (Combat Specialization Ability - Recklessness - Basic Unit): The Berserker 
+			  will leap at it's target if it is not within attacking range, dealing damage to it's target.
 
 RUBY UNITS
 __________
@@ -153,10 +154,10 @@ __________
 -	Well balanced offensive and defensive stats, slightly better than the Soldier unit in every way.
 -	Abilities:
 	-	1. IF TECH
-			- Recklessness (Combat Special Ability - Ruby Unit): Automatons can release a constant wave
-			  of tachyon particles, dealing initially small damage to all enemy units and buildings within
-			  range, with the damage ramping up in a short amount of time to a large amount of damage.
-			  The Automaton is unable to move or attack while channeling this ability.
+			- Tachyon Bombardment (Combat Specialization Ability - Recklessness - Ruby Unit): Automatons 
+			  can release a constant wave of tachyon particles, dealing initially small damage to all enemy 
+			  units and buildings within range, with the damage ramping up in a short amount of time to a 
+			  large amount of damage. The Automaton is unable to move or attack while channeling this ability.
 	-	2. IF TECH
 			- Shocktroopers: The player can teleport all Automatons not currently in combat to a location
 			  within range of a friendly unit that is currently in combat. This ability has a long
@@ -229,10 +230,10 @@ __________
 		Auto Cast Option - Targets an enemy that took damage within the last second if the cooldown
 		is available.
 	-	4. IF TECH
-			- Protectorate (Combat Special Ability - Ruby Unit): The Wizard protects a friendly unit,
-			  redirecting a portion of the damage taken by that unit to the nearest Knight within
-			  range. If there is no Knight within range, the Wizard instead redirects the damage
-			  to itself.
+			- Redirect (Combat Specialization Ability - Protectorate - Ruby Unit): The Wizard protects 
+			  a friendly unit, redirecting a portion of the damage taken by that unit to the nearest
+			  Knight within range. If there is no Knight within range, the Wizard instead redirects 
+			  the damage to itself.
 
 
 -	Subverter
@@ -260,9 +261,10 @@ __________
 			  building can be selected but no timers like unit creation will count down while disabled,
 			  and the building cannot be used for any purpose while disabled.
 	-	3. IF TECH
-			- Explode: The Subverter now carries a powerful bomb everywhere it travels. If activated
-			  (must be manually activated), the Subverter explodes, dealing massive magic damage to itself
-			  and all units (friendly included) that are adjacent to it.
+			- Explode (Combat Specialization Ability - Stealth - Ruby Unit): The Subverter now carries a 
+			  powerful bomb everywhere it travels. If activated (must be manually activated), the Subverter 
+			  explodes, dealing massive magic damage to itself and all units (friendly included) that are 
+			  adjacent to it.
 
 
 -	Warlock

--- a/scripts/initialize_object_data/initialize_object_data.gml
+++ b/scripts/initialize_object_data/initialize_object_data.gml
@@ -123,7 +123,7 @@ function initialize_object_data() {
 			// increased by 15%.
 			objectSkillfulUpgradeSupportMultiplier = 0.85;
 			
-			// Combat Special Ability Availability variables
+			// Combat Specialization Ability Availability variables
 			objectHasCombatSpecializationAbility = false;
 			objectCanUseCombatSpecializationAbility = false;
 			
@@ -249,10 +249,10 @@ function initialize_object_data() {
 			// the total enrageDamageBonus value to it's original value plus 1.
 			objectSkillfulUpgradeRecklessnessEnhancement = 4;
 			
-			// Combat Special Ability Availability variables
+			// Combat Specialization Ability Availability variables
 			objectHasCombatSpecializationAbility = true;
 			objectCanUseCombatSpecializationAbility = false
-			recklessLeapActive = false; // Combat Special Ability
+			recklessLeapActive = false; // Combat Specialization Ability
 			recklessLeapDamage = 30;
 			recklessLeapRange = 4 * 16;
 			recklessLeapCooldown = 12 * room_speed;
@@ -345,7 +345,7 @@ function initialize_object_data() {
 			// additional 1 damage.
 			objectCourageUpgradeDamageEnhancement = 0.5;
 			
-			// Combat Special Ability Availability variables
+			// Combat Specialization Ability Availability variables
 			objectHasCombatSpecializationAbility = false;
 			objectCanUseCombatSpecializationAbility = false;
 			
@@ -441,10 +441,10 @@ function initialize_object_data() {
 			objectCourageUpgradeActive = false; // Barracks Offensive 2c
 			objectCourageUpgradeResistanceEnhancement = 0.1;
 			
-			// Combat Special Ability Availability variables
+			// Combat Specialization Ability Availability variables
 			objectHasCombatSpecializationAbility = true;
 			objectCanUseCombatSpecializationAbility = false;
-			nanobotEncasementActive = false; // Combat Special Ability
+			nanobotEncasementActive = false; // Combat Specialization Ability
 			nanobotEncasementCooldown = 30 * room_speed;
 			nanobotEncasementCooldownTimer = 0;
 			nanobotEncasementDuration = 5 * room_speed;
@@ -520,7 +520,7 @@ function initialize_object_data() {
 			// damage of Rangers once the upgrade is unlocked at the Laboratory.
 			objectSkillfulUpgradeRangeTrainingEnhancement = 3;
 			
-			// Combat Special Ability Availability variables
+			// Combat Specialization Ability Availability variables
 			objectHasCombatSpecializationAbility = false;
 			objectCanUseCombatSpecializationAbility = false;
 			
@@ -602,9 +602,12 @@ function initialize_object_data() {
 			// 1.5x damage, or (1.5 * 0.5 = 0.75).
 			piercingStrikePenetration = 1.5;
 			
-			// Combat Special Ability Availability variables
+			// Combat Specialization Ability Availability variables
 			objectHasCombatSpecializationAbility = true;
 			objectCanUseCombatSpecializationAbility = false;
+			assassinInvisibilityResetAvailable = false;
+			assassinInvisibilityResetCooldown = room_speed * 15;
+			assassinInvisibilityResetCooldownTimer = 0;
 			
 			// Combat variables
 			objectAttackRange = 1 * 16;
@@ -675,28 +678,28 @@ function initialize_object_data() {
 			objectSpecialAttackAreaOfEffectBuildingDamage = 100;
 			objectSpecialAttackDamageType = "Magic";
 			objectSpecialAttackCooldown = 10 * room_speed;
-			objectSpecialAttackTimer = 0;
+			objectSpecialAttackCooldownTimer = 0;
 			// Singed Circuit is an unlocked passive that reduces the cooldown of the Wizard's special
 			// ability if it hits enough targets with a cast of that special ability.
 			singedCircuitActive = false; // Temple Innovation 3a
 			singedCircuitSpecialAttackCooldownReduction = 5 * room_speed;
 			
-			// Combat Special Ability Availability variables
+			// Combat Specialization Ability Availability variables
 			objectHasCombatSpecializationAbility = true;
 			objectCanUseCombatSpecializationAbility = false;
-			// The Wizard's combat specialization ability is to redirect damage received by a chosen
+			// The Wizard's combat specialization ability Redirect is to redirect damage received by a chosen
 			// target to a nearby Knight in combat. If there are no Knights nearby, the damage is instead
 			// redirected to the Wizard.
-			objectCombatSpecializationAbilityActive = false;
-			objectCombatSpecializationTimer = 20 * room_speed;
-			objectCombatSpecializationCooldown = -1;
-			objectCombatSpecializationRange = 6 * 16;
-			objectCombatSpecializationKnightInRange = false;
-			objectCombatSpecializationRedirectKnightTarget = noone;
-			objectCombatSpecializationRedirectProtectTarget = noone;
-			objectCombatSpecializationRedirectProtectMultiplier = 0.7;
-			objectCombatSpecializationDurationTimer = 5 * room_speed;
-			objectCombatSpecializationDurationCooldown = -1;
+			redirectAbilityActive = false;
+			redirectCooldown = 20 * room_speed;
+			redirectCooldownTimer = -1;
+			redirectRange = 6 * 16;
+			redirectKnightInRange = false;
+			redirectKnightTarget = noone;
+			redirectProtectTarget = noone;
+			redirectProtectMultiplier = 0.7;
+			redirectDuration = 5 * room_speed;
+			redirectDurationTimer = -1;
 			
 			// Various Capability Upgrades
 			wizardsCanLink = false; // Temple Innovation 2a
@@ -720,13 +723,13 @@ function initialize_object_data() {
 			objectAttackSpeedTimer = 0;
 			objectAttackDamage = 8; // Each magic missile deals this amount of damage, meaning because there are 3 in each attack volley, the Wizard's total damage is 3x this value.
 			objectAttackDamageType = "Magic";
-			
 			// For resistances, they're multipliers. The closer to 0 the higher resistance it has.
 			// Anything above 1 means it has a negative resistance and takes more damage than normal
 			// from that damage type.
 			objectSlashResistance = 1.25;
 			objectPierceResistance = 1;
 			objectMagicResistance = 0.95;
+			
 			// Sprite setting array
 			unitSprite[unitAction.idle][unitDirection.right] = spr_wizard_right_idle;
 			unitSprite[unitAction.idle][unitDirection.up] = spr_wizard_back_idle;
@@ -776,10 +779,14 @@ function initialize_object_data() {
 			objectSightRange = 7 * 16;
 			
 			// Special Ability Availability variables
+			// Special Attack is just summoning a demon. As it's the Warlock's signature ability, it's the only special
+			// ability in the game that is unlocked by default.
 			objectHasSpecialAbility = true;
 			objectCanUseSpecialAbility = true;
+			objectSpecialAttackCooldown = 10 * room_speed;
+			objectSpecialAttackCooldownTimer = 0;
 			
-			// Combat Special Ability Availability variables
+			// Combat Specialization Ability Availability variables
 			objectHasCombatSpecializationAbility = false;
 			objectCanUseCombatSpecializationAbility = false;
 			
@@ -826,11 +833,13 @@ function initialize_object_data() {
 			objectAttackSpeedTimer = 0;
 			objectAttackDamage = 10;
 			objectAttackDamageType = "Magic";
-			objectSpecialAttackCooldown = 10 * room_speed;
-			objectSpecialAttackTimer = 0;
+			// For resistances, they're multipliers. The closer to 0 the higher resistance it has.
+			// Anything above 1 means it has a negative resistance and takes more damage than normal
+			// from that damage type.
 			objectSlashResistance = 1.25;
 			objectPierceResistance = 1;
 			objectMagicResistance = 0.95;
+			
 			// Sprite setting array
 			unitSprite[unitAction.idle][unitDirection.right] = spr_warlock_right_idle;
 			unitSprite[unitAction.idle][unitDirection.up] = spr_warlock_back_idle;
@@ -879,7 +888,7 @@ function initialize_object_data() {
 			objectIsRubyUnit = true;
 			objectSightRange = 5 * 16;
 			
-			// Special and Combat Special Availability variables (none for Demon)
+			// Special and Combat Specialization Availability variables (none for Demon)
 			objectHasSpecialAbility = false;
 			objectCanUseSpecialAbility = false;
 			objectSkillfulUpgradeActive = false;
@@ -898,20 +907,12 @@ function initialize_object_data() {
 			// armor of the unit in question to lower the resistance multiplier *value*, thereby increasing the resistance's
 			// *overall reduction*.
 			arcaneArmorMagicArmorBonus = -0.15;
-			
-			// Combat variables
-			objectAttackRange = 1 * 16;
-			objectCombatAggroRange = 5; // This is half the width of the square in mp_grid unit sizes to detect enemies in, centered on this object
-			objectAttackSpeed = 0.5 * room_speed;
-			objectAttackSpeedTimer = 0;
-			objectAttackDamage = 8;
-			objectAttackDamageType = "Pierce";
 			// This is the time limit to determine how long the Demon should last before dying automatically if permanent pets 
 			// aren't unlocked.
 			// The time limit is determined by the Warlock and it's upgrades, but the timer itself is managed by the Demon that
 			// is summoned. This greatly simplifies the way summons are handled.
 			summonedDemonsTimeLimitTimer = -1;
-			// If this is ever noone, the Demon will die shortly after. A Demon will always be attached to a Warlock.
+			// If this is ever noone, the Demon will die shortly after. A Demon must always be attached to a Warlock.
 			summonedDemonsSummonedByWarlockID = noone;
 			// This countdown sits at 4 seconds. If the Warlock the Demon is attached to dies, this begins a countdown, and the
 			// Demon dies at the end of the countdown.
@@ -920,8 +921,16 @@ function initialize_object_data() {
 			// the Warlock's parent variable by the same name, so this is by default set to -1.
 			summonedDemonsMaxTetherRange = -1;
 			// Demons will immediately die if they exceed this distance from their master, no matter their current action. Set by
-			// the Warlock's parent variable by the same name, so this are by default set to -1.
+			// the Warlock's parent variable by the same name, so this is by default set to -1.
 			summonedDemonsMaxDeathRange = -1;
+			
+			// Combat variables
+			objectAttackRange = 1 * 16;
+			objectCombatAggroRange = 5; // This is half the width of the square in mp_grid unit sizes to detect enemies in, centered on this object
+			objectAttackSpeed = 0.5 * room_speed;
+			objectAttackSpeedTimer = 0;
+			objectAttackDamage = 8;
+			objectAttackDamageType = "Pierce";
 			// For resistances, they're multipliers. The closer to 0 the higher resistance it has.
 			// Anything above 1 means it has a negative resistance and takes more damage than normal
 			// from that damage type.
@@ -979,7 +988,7 @@ function initialize_object_data() {
 			objectHasSpecialAbility = false;
 			objectCanUseSpecialAbility = false;
 			
-			// Combat Special Ability Availability variables
+			// Combat Specialization Ability Availability variables
 			objectHasCombatSpecializationAbility = false;
 			objectCanUseCombatSpecializationAbility = false;
 			
@@ -1081,13 +1090,13 @@ function initialize_object_data() {
 			subverterCopyCooldown = 30 * room_speed;
 			subverterCopyCooldownTimer = 0;
 			
-			// Combat Special Ability Availability variables
+			// Combat Specialization Ability Availability variables
 			objectHasCombatSpecializationAbility = true;
 			objectCanUseCombatSpecializationAbility = false;
-			// The Subverter's Combat Special Ability is to explode itself and adjacent squares, dealing MASSIVE magic damage.
-			objectCombatSpecializationAttackDamage = 500;
-			objectCombatSpecializationAttackDamageType = "Magic";
-			objectCombatSpecializationAttackAoERadius = 2 * 16; // A range of 2 means only the adjacent squares will be affected.
+			// The Subverter's Combat Specialization Ability "Explode" is to explode itself and adjacent squares, dealing MASSIVE magic damage.
+			explodeAttackDamage = 500;
+			explodeAttackDamageType = "Magic";
+			explodeAttackAoERadius = 2 * 16; // A range of 2 means only the adjacent squares will be affected.
 			
 			// Various Capability Upgrades
 			preparationActive = false; // Temple Offensive 3b
@@ -1159,7 +1168,7 @@ function initialize_object_data() {
 			objectIsRubyUnit = true;
 			objectSightRange = 6 * 16;
 			
-			// Special and Combat Special Ability Availability variables (none for Abomination)
+			// Special and Combat Specialization Ability Availability variables (none for Abomination)
 			objectHasSpecialAbility = false;
 			objectCanUseSpecialAbility = false;
 			objectHasCombatSpecializationAbility = false;
@@ -1367,7 +1376,7 @@ function initialize_object_data() {
 			objectHasSpecialAbility = false;
 			objectCanUseSpecialAbility = false;
 			
-			// Combat Special Ability Availability variables
+			// Combat Specialization Ability Availability variables
 			objectHasCombatSpecializationAbility = true;
 			objectCanUseCombatSpecializationAbility = false;
 			

--- a/scripts/initialize_stat_data/initialize_stat_data.gml
+++ b/scripts/initialize_stat_data/initialize_stat_data.gml
@@ -315,19 +315,19 @@ function _temple() constructor {
 				60, 100, 0, 200, 100, noone, noone, noone);
 	// The next option will only appear if the variable given (second to last argument) located in the object
 	// or struct (third to last argument) is equal to the value expected (last argument).
-	subverterCombatSpecialAbilities = new _upgrade_options("Subverter Combat Special Abilities", "Unlocks the Combat Special Abilities for the Subverter.", 
+	subverterCombatSpecializationAbility = new _upgrade_options("Explode", "Unlocks the Combat Specialization Ability 'Explode' for the Subverter.", 
 				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.three, eUpgradeSibling.noone, 
 				false, 2, false, noone, "Temple", "Subverter", "objectCanUseCombatSpecializationAbility", 
 				noone, 1, 60, 150, 50, 100, 100, "Player", "combatSpecializationChosen", "Stealth");
 	// The next option will only appear if the variable given (second to last argument) located in the object
 	// or struct (third to last argument) is equal to the value expected (last argument).
-	automatonCombatSpecialAbilities = new _upgrade_options("Automaton Combat Special Abilities", "Unlocks the Combat Special Abilities for the Automaton.", 
+	automatonCombatSpecializationAbility = new _upgrade_options("Tachyon Bombardment", "Unlocks the Combat Specialization Ability 'Tachyon Bombardment' for the Automaton.", 
 				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.three, eUpgradeSibling.noone, 
 				false, 2, false, noone, "Temple", "Automaton", "objectCanUseCombatSpecializationAbility", 
 				noone, 1, 60, 150, 50, 100, 100, "Player", "combatSpecializationChosen", "Recklessness");
 	// The next option will only appear if the variable given (second to last argument) located in the object
 	// or struct (third to last argument) is equal to the value expected (last argument).
-	wizardCombatSpecialAbilities = new _upgrade_options("Wizard Combat Specialization Abilities", "Unlocks the Combat Special Abilities for the Wizard.", 
+	wizardCombatSpecializationAbility = new _upgrade_options("Redirect", "Unlocks the Combat Specialization Ability 'Redirect' for the Wizard.", 
 				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.three, eUpgradeSibling.noone, 
 				false, 2, false, noone, "Temple", "Wizard", "objectCanUseCombatSpecializationAbility", 
 				noone, 1, 60, 150, 50, 100, 100, "Player", "combatSpecializationChosen", "Protectorate");
@@ -505,21 +505,21 @@ function _barracks() constructor {
 				250, 250, 250, 0, noone, noone, noone);
 	// The next option will only appear if the variable given (second to last argument) located in the object
 	// or struct (third to last argument) is equal to the value expected (last argument).
-	rogueCombatSpecialAbilities = new _upgrade_options("Rogue Combat Special Abilities", "Unlocks the Combat Special Abilities for the Rogue.", 
+	rogueCombatSpecializationAbility = new _upgrade_options("Assassin", "Unlocks the Combat Specialization Ability 'Assassin' for the Rogue.", 
 				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.two, eUpgradeSibling.a, 
 				false, 2, false, noone, "Barracks", "Rogue", "objectCanUseCombatSpecializationAbility",
 				noone, 1, 60, 150, 50, 100, 0, "Player" /*Located in the player struct for each player*/, 
 				"combatSpecializationChosen", "Stealth");
 	// The next option will only appear if the variable given (second to last argument) located in the object
 	// or struct (third to last argument) is equal to the value expected (last argument).
-	berserkerCombatSpecialAbilities = new _upgrade_options("Berserker Combat Special Abilities", "Unlocks the Combat Special Abilities for the Berserker.", 
+	berserkerCombatSpecializationAbility = new _upgrade_options("Reckless Leap", "Unlocks the Combat Specialization Ability 'Reckless Leap' for the Berserker.", 
 				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.two, eUpgradeSibling.a, 
 				false, 2, false, noone, "Barracks", "Berserker", "objectCanUseCombatSpecializationAbility", 
 				noone, 1, 60, 150, 50, 100, 0, "Player" /*Located in the player struct for each player*/, 
 				"combatSpecializationChosen", "Recklessness");
 	// The next option will only appear if the variable given (second to last argument) located in the object
 	// or struct (third to last argument) is equal to the value expected (last argument).
-	knightCombatSpecialAbilities = new _upgrade_options("Knight Combat Special Abilities", "Unlocks the Combat Special Abilities for the Knight.", 
+	knightCombatSpecializationAbility = new _upgrade_options("Nanobot Encasement", "Unlocks the Combat Specialization Ability 'Nanobot Encasement' for the Knight.", 
 				eUpgradeTree.technology, eUpgradeType.special, eUpgradeOrder.two, eUpgradeSibling.a, 
 				false, 2, false, noone, "Barracks", "Knight", "objectCanUseCombatSpecializationAbility", 
 				noone, 1, 60, 150, 50, 100, 0, "Player" /*Located in the player struct for each player*/, 


### PR DESCRIPTION
- Differentiated between "Special Abilities" and "Combat Special_ization_ Abilities" to make it more clear when reading code which ability is being referenced.
- Named all Combat Specialization Abilities for each unit to make it far easier to tell what is being referenced.

Continued to carefully verify full connection and functionality between two scripts (initialize_object_data and initialize_stat_data), and the connected description notes (UnitsAbilities, PlayerAdvancementSkillTrees, and all building skill tree notes [OutpostSkillTree, StorehouseSkillTree, etc.]) Finished off at Rogue, sorted by UnitsAbilities note file, need to complete everything below.